### PR TITLE
Add PDF/PPTX export endpoints and UI buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,19 @@
         #copy-button:hover {
             background-color: #3f51b5;
         }
+        #pdf-button, #pptx-button {
+            padding: 0.5rem 1rem;
+            font-size: 0.9rem;
+            color: #fff;
+            background-color: #43a047;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            margin-left: 5px;
+        }
+        #pdf-button:hover, #pptx-button:hover {
+            background-color: #2e7d32;
+        }
         #response {
             margin-top: 0.5rem;
             padding: 1rem;
@@ -139,6 +152,8 @@
             <pre id="response"></pre> <!-- Using <pre> for better formatting -->
             <div id="output-controls" style="display: none; margin-top: 15px;">
                 <button id="copy-button">Copy Markdown</button>
+                <button id="pdf-button" disabled>Download PDF</button>
+                <button id="pptx-button" disabled>Download PPTX</button>
                 <a href="https://drive.google.com/drive/folders/1FZfowYTtmBif3G8FyGWJA8-MQ_beoRmv" target="_blank" id="branding-assets-button">
                     Get Branding Assets
                 </a>
@@ -152,6 +167,8 @@
         const responsePre = document.getElementById('response');
         const outputControls = document.getElementById('output-controls'); // Get the new div
         const copyButton = document.getElementById('copy-button');
+        const pdfButton = document.getElementById('pdf-button');
+        const pptxButton = document.getElementById('pptx-button');
         // const brandingAssetsButton = document.getElementById('branding-assets-button'); // Not strictly needed for visibility control if parent is handled
 
         form.addEventListener('submit', async (event) => {
@@ -181,10 +198,14 @@
                     responsePre.textContent = result.fullSow;
                     outputControls.style.display = 'block'; // Show output controls div
                     copyButton.textContent = 'Copy Markdown'; // Reset button text
+                    pdfButton.disabled = false;
+                    pptxButton.disabled = false;
                 } else {
                     // Otherwise, display the whole JSON response
                     responsePre.textContent = JSON.stringify(result, null, 2);
                     outputControls.style.display = 'none'; // Ensure controls are hidden if no SOW
+                    pdfButton.disabled = true;
+                    pptxButton.disabled = true;
                 }
 
 
@@ -193,6 +214,8 @@
                 responsePre.style.color = '#c62828';
                 responsePre.textContent = 'Error: Could not connect to the server. Is it running?';
                 outputControls.style.display = 'none'; // Ensure controls are hidden on error
+                pdfButton.disabled = true;
+                pptxButton.disabled = true;
                 console.error('Upload failed:', error);
             }
         });
@@ -214,6 +237,38 @@
                 copyButton.textContent = 'Copy Markdown';
             }, 2000);
         });
+
+        async function downloadFile(format) {
+            const button = format === 'pdf' ? pdfButton : pptxButton;
+            button.textContent = 'Downloading...';
+            button.disabled = true;
+            try {
+                const response = await fetch(`/export/${format}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ markdown: responsePre.textContent })
+                });
+                if (!response.ok) throw new Error('Export failed');
+                const blob = await response.blob();
+                const url = window.URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = format === 'pdf' ? 'sow.pdf' : 'sow.pptx';
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+                window.URL.revokeObjectURL(url);
+            } catch (err) {
+                alert('Export failed');
+                console.error(err);
+            } finally {
+                button.textContent = format === 'pdf' ? 'Download PDF' : 'Download PPTX';
+                button.disabled = false;
+            }
+        }
+
+        pdfButton.addEventListener('click', () => downloadFile('pdf'));
+        pptxButton.addEventListener('click', () => downloadFile('pptx'));
     </script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "google-auth-library": "^9.11.0",
     "googleapis": "^137.1.0",
     "mammoth": "^1.7.2",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "md-to-pdf": "^5.1.0",
+    "pptxgenjs": "^3.9.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -11,6 +11,8 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const { google } = require('googleapis');
 const { GoogleAuth } = require('google-auth-library');
 const pdf = require('pdf-parse');
+const { mdToPdf } = require('md-to-pdf');
+const PPTX = require('pptxgenjs');
 const { brandContext } = require('./config/brandContext');
 
 // 2. Initialize Express App & Gemini AI
@@ -1031,6 +1033,73 @@ app.post('/upload', async (req, res) => {
     } catch (error) {
         console.error('Error in the SOW generation workflow:', error);
         res.status(500).json({ message: 'An error occurred during the workflow.', error: error.message });
+    }
+});
+
+// --- Export Endpoints ---
+app.post('/export/pdf', async (req, res) => {
+    try {
+        const { markdown } = req.body || {};
+        if (!markdown) {
+            return res.status(400).json({ message: 'No markdown provided' });
+        }
+        const pdfBuf = await mdToPdf({ content: markdown }, {
+            stylesheet: path.join(__dirname, 'templates', 'pdf.css'),
+            as_buffer: true
+        });
+        res.contentType('application/pdf');
+        res.send(pdfBuf.content);
+    } catch (err) {
+        console.error('PDF export error:', err);
+        res.status(500).json({ message: 'Failed to generate PDF' });
+    }
+});
+
+app.post('/export/pptx', async (req, res) => {
+    try {
+        const { markdown } = req.body || {};
+        if (!markdown) {
+            return res.status(400).json({ message: 'No markdown provided' });
+        }
+
+        const slidesMarkdown = markdown.split(/\n---\n/);
+        const pptx = new PPTX();
+        pptx.layout = 'LAYOUT_WIDE';
+
+        slidesMarkdown.forEach((md) => {
+            const slide = pptx.addSlide();
+            const lines = md.split(/\n/);
+            let y = 0.5;
+            lines.forEach(line => {
+                if (/^#+/.test(line)) {
+                    const level = line.match(/^#+/)[0].length;
+                    const text = line.replace(/^#+\s*/, '');
+                    slide.addText(text, { x: 0.5, y, fontSize: level === 1 ? 24 : 20, bold: level === 1 });
+                    y += 0.6;
+                } else if (/^-\s+/.test(line)) {
+                    slide.addText(line.replace(/^-\s+/, ''), { x: 0.8, y, fontSize: 14, bullet: true });
+                    y += 0.3;
+                }
+            });
+
+            if (/stakeholders/i.test(md)) {
+                brandContext.stakeholders.forEach((s, i) => {
+                    const x = 0.5 + (i % 3) * 3;
+                    const yPos = 3 + Math.floor(i / 3) * 2.5;
+                    if (s.imagePath) {
+                        slide.addImage({ path: s.imagePath, x, y: yPos, w: 2, h: 2 });
+                    }
+                    slide.addText(`${s.name}\n${s.title}`, { x, y: yPos + 2, w: 2, fontSize: 10, align: 'center' });
+                });
+            }
+        });
+
+        const buffer = await pptx.write('nodebuffer');
+        res.setHeader('Content-Disposition', 'attachment; filename="sow.pptx"');
+        res.send(buffer);
+    } catch (err) {
+        console.error('PPTX export error:', err);
+        res.status(500).json({ message: 'Failed to generate PPTX' });
     }
 });
 

--- a/templates/pdf.css
+++ b/templates/pdf.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  padding: 2rem;
+}
+
+h1, h2, h3 {
+  color: #283638;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+td, th {
+  border: 1px solid #ccc;
+  padding: 4px;
+}
+
+code {
+  background: #f5f5f5;
+  padding: 2px 4px;
+  border-radius: 4px;
+}

--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Scope of Work</title>
+    <style>{{{css}}}</style>
+</head>
+<body>
+{{{html}}}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support converting generated markdown to PDF and PPTX
- add templates and styles for PDF export
- expose `/export/pdf` and `/export/pptx` endpoints
- add download buttons in front‑end with JS handlers
- include dependencies `md-to-pdf` and `pptxgenjs`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fd764154832aaedc055bada135ea