### PR TITLE
Fix Reveal.js init for desktop preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,9 +299,9 @@
                 mobileToggle.disabled = true;
             } else {
                 currentMd = responsePre.textContent;
+                slidePreview.classList.remove('hidden'); // ensure element is visible before Reveal init
                 buildSlides(currentMd);
                 responsePre.style.display = 'none';
-                slidePreview.classList.remove('hidden');
                 previewButton.textContent = 'Back to Editor';
             }
         });


### PR DESCRIPTION
## Summary
- fix preview button logic to make slide container visible before initializing Reveal.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687926f3030c832aa39de3ddf6256c43