### PR TITLE
Add Process Street tasks route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ScopeGenApp
 Used to convert BRD into client ready SOW 
+
+## Environment Variables
+
+Create a `.env` file with the following entries:
+
+```
+GEMINI_API_KEY=<your gemini key>
+PS_API_KEY=<your process street api key>
+```
+
+The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/brandContext.test.js"
+    "test": "node tests/brandContext.test.js && node tests/psTasksRoute.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/tests/psTasksRoute.test.js
+++ b/tests/psTasksRoute.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+const mockTasks = [{id:1},{id:2}];
+async function mockFetch() {
+  return {
+    status: 200,
+    ok: true,
+    json: async () => ({ tasks: mockTasks })
+  };
+}
+
+global.fetch = mockFetch;
+process.env.PS_API_KEY = "test_key";
+const app = require("../server");
+
+async function run() {
+  const layer = app._router.stack.find(s => s.route && s.route.path === '/ps/tasks/:runId').route.stack[0].handle;
+  const req = { params: { runId: '123' } };
+  const res = {
+    statusCode: 200,
+    data: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.data = payload; }
+  };
+  await layer(req, res);
+  assert.strictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.data, mockTasks);
+  console.log('ps tasks route returns tasks');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- configure Process Street API key and base URL
- add `/ps/tasks/:runId` endpoint to fetch tasks
- export express `app` for testing
- document new `PS_API_KEY` variable
- add unit test for the new route
- run tests (fail due to missing dependencies)

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6883606cdcb8832aac590d5d9e83fa9d