### PR TITLE
Implement tasks list UI and fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,20 @@
 
     <div class="container">
         <h1>Upload BRD Document</h1>
+        <div class="mb-4">
+            <label for="runIdInput" class="block text-sm font-medium text-gray-700">Process Street Run ID</label>
+            <input id="runIdInput" type="text" class="mt-1 block w-full border rounded p-2" placeholder="Enter runId">
+            <button id="loadTasksBtn" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Load Tasks</button>
+        </div>
+        <div id="tasksContainer" class="hidden mb-4">
+            <h2 class="text-lg font-semibold">Tasks</h2>
+            <table id="tasksTable" class="min-w-full text-left">
+                <thead>
+                    <tr><th>Name</th><th>Created At</th><th>Actions</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
         <form id="uploadForm" enctype="multipart/form-data">
             <input type="file" id="brdFileInput" name="brdFile" required>
             <button type="submit" class="main-button">Generate SOW</button>
@@ -181,12 +195,86 @@
         const previewButton = document.getElementById('preview-button');
         const mobileToggle = document.getElementById('mobile-toggle');
         const slidePreview = document.getElementById('slide-preview');
+        const runIdInput = document.getElementById('runIdInput');
+        const loadTasksBtn = document.getElementById('loadTasksBtn');
+        const tasksContainer = document.getElementById('tasksContainer');
+        const tasksTable = document.getElementById('tasksTable');
         let brandContext = null;
         let revealDeck = null;
         let mobileMode = false;
         let currentMd = '';
         fetch('/brandcontext').then(r => r.json()).then(bc => brandContext = bc);
         // const brandingAssetsButton = document.getElementById('branding-assets-button'); // Not strictly needed for visibility control if parent is handled
+
+        loadTasksBtn.addEventListener('click', async () => {
+            const runId = runIdInput.value.trim();
+            if (!runId) return alert('Please enter a runId');
+
+            const tblBody = tasksTable.querySelector('tbody');
+            tblBody.innerHTML = '';
+            tasksContainer.classList.add('hidden');
+
+            try {
+                const res = await fetch(`/ps/tasks/${encodeURIComponent(runId)}`);
+                if (!res.ok) {
+                    const err = await res.json();
+                    return alert(`Error: ${err.error || res.statusText}`);
+                }
+                const tasks = await res.json();
+                if (tasks.length === 0) {
+                    return alert('No tasks found for this run.');
+                }
+
+                tasks.forEach(task => {
+                    const tr = document.createElement('tr');
+                    const created = new Date(task.createdDate || task.updatedDate).toLocaleString();
+                    tr.innerHTML = `
+                        <td>${task.name}</td>
+                        <td>${created}</td>
+                        <td>
+                          <button data-id="${task.id}" class="viewTaskBtn underline">View</button>
+                          <button data-id="${task.id}" class="pdfTaskBtn underline ml-2">PDF</button>
+                        </td>
+                    `;
+                    tblBody.appendChild(tr);
+                });
+
+                tasksContainer.classList.remove('hidden');
+            } catch (e) {
+                console.error(e);
+                alert('Failed to load tasks.');
+            }
+        });
+
+        tasksTable.addEventListener('click', async (e) => {
+            const runId = runIdInput.value.trim();
+            if (e.target.classList.contains('viewTaskBtn')) {
+                const taskId = e.target.dataset.id;
+                const res = await fetch(`/ps/tasks/${runId}/${taskId}`);
+                if (!res.ok) return alert('Error fetching task');
+                const md = await res.text();
+                responsePre.textContent = md;
+                responseArea.style.display = 'block';
+                outputControls.style.display = 'none';
+            }
+            if (e.target.classList.contains('pdfTaskBtn')) {
+                const taskId = e.target.dataset.id;
+                const mdRes = await fetch(`/ps/tasks/${runId}/${taskId}`);
+                if (!mdRes.ok) return alert('Error fetching task');
+                const markdown = await mdRes.text();
+                const pdfRes = await fetch('/export/pdf', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ markdown })
+                });
+                if (!pdfRes.ok) return alert('PDF export failed');
+                const blob = await pdfRes.blob();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url; a.download = `${taskId}.pdf`;
+                a.click(); URL.revokeObjectURL(url);
+            }
+        });
 
         form.addEventListener('submit', async (event) => {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- add tasks loading UI and table
- implement client logic to load tasks list and view/download each

## Testing
- `node tests/psTasksRoute.test.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6883679de3a8832a8ace51eb3f3ac84e