### PR TITLE
Add workflow run selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,10 @@
             <label for="templateIdInput" class="block text-sm font-medium text-gray-700">Workflow Template ID</label>
             <input id="templateIdInput" type="text" class="mt-1 block w-full border rounded p-2" placeholder="Enter workflow template ID">
         </div>
+        <button id="loadRunsBtn" class="px-4 py-2 bg-indigo-600 text-white rounded">Load Runs</button>
+        <select id="runsSelect" class="mt-2 block w-full border rounded p-2 hidden">
+          <option value="">Select a run…</option>
+        </select>
         <div class="mb-4">
             <label for="runNameInput" class="block text-sm font-medium text-gray-700">New Run Name</label>
             <input id="runNameInput" type="text" class="mt-1 block w-full border rounded p-2" placeholder="Enter run name">
@@ -211,12 +215,41 @@
         const templateIdInput = document.getElementById('templateIdInput');
         const runNameInput = document.getElementById('runNameInput');
         const createRunBtn = document.getElementById('createRunBtn');
+        const loadRunsBtn = document.getElementById('loadRunsBtn');
+        const runsSelect   = document.getElementById('runsSelect');
         let brandContext = null;
         let revealDeck = null;
         let mobileMode = false;
         let currentMd = '';
         fetch('/brandcontext').then(r => r.json()).then(bc => brandContext = bc);
         // const brandingAssetsButton = document.getElementById('branding-assets-button'); // Not strictly needed for visibility control if parent is handled
+
+        loadRunsBtn.addEventListener('click', async () => {
+          const templateId = templateIdInput.value.trim();
+          if (!templateId) return alert('Enter a Workflow Template ID first');
+          try {
+            const res = await fetch(`/ps/runs?workflowId=${encodeURIComponent(templateId)}`);
+            if (!res.ok) throw new Error(await res.text());
+            const runs = await res.json();
+            runsSelect.innerHTML = '<option value="">Select a run…</option>';
+            runs.forEach(r => {
+              const opt = document.createElement('option');
+              opt.value = r.id;
+              opt.textContent = `${r.name}\u00A0\u2013\u00A0${new Date(r.updatedDate).toLocaleDateString()}`;
+              runsSelect.appendChild(opt);
+            });
+            runsSelect.classList.remove('hidden');
+          } catch (e) {
+            console.error(e);
+            alert('Failed to load runs.');
+          }
+        });
+
+        runsSelect.addEventListener('change', () => {
+          const runId = runsSelect.value;
+          runIdInput.value = runId;
+          if (runId) loadTasksBtn.click();
+        });
 
         createRunBtn.addEventListener('click', async () => {
             const workflowId = templateIdInput.value.trim();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js"
+    "test": "node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -1087,6 +1087,26 @@ app.get('/ps/tasks/:runId/:taskId', async (req, res) => {
 });
 
 /**
+ * GET /ps/runs?workflowId=<templateId>
+ * Returns up to 200 latest runs for that workflow template.
+ */
+app.get('/ps/runs', async (req, res) => {
+  const { workflowId } = req.query;
+  if (!workflowId) return res.status(400).json({ error: 'workflowId is required' });
+
+  const url = `${PS_BASE_URL}/workflow-runs?workflowId=${encodeURIComponent(workflowId)}`;
+  try {
+    const psRes = await fetch(url, { headers: { 'X-API-Key': PS_API_KEY } });
+    if (!psRes.ok) return res.status(psRes.status).json({ error: psRes.statusText });
+    const { workflowRuns } = await psRes.json();
+    return res.json(workflowRuns);
+  } catch (err) {
+    console.error('❌ Error listing workflow runs:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
  * POST /ps/runs
  * Body: { workflowId: string, name: string, dueDate?: string }
  * Creates a new workflow run and returns its ID.

--- a/tests/psListRunsRoute.test.js
+++ b/tests/psListRunsRoute.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+process.env.PS_API_KEY = 'test_key';
+
+const mockRuns = [{ id: 'r1', name: 'Run 1', updatedDate: '2024-01-01T00:00:00Z' }];
+
+global.fetch = async (url) => {
+  assert.ok(url.includes('/workflow-runs?workflowId=w123'));
+  return {
+    status: 200,
+    ok: true,
+    json: async () => ({ workflowRuns: mockRuns })
+  };
+};
+
+const app = require('../server');
+const handler = app._router.stack
+  .find(l => l.route?.path === '/ps/runs' && l.route.methods.get)
+  .route.stack[0].handle;
+
+(async () => {
+  const req = { query: { workflowId: 'w123' } };
+  let data = null;
+  const res = {
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { data = payload; }
+  };
+
+  await handler(req, res);
+  assert.strictEqual(res.statusCode, undefined); // default 200
+  assert.deepStrictEqual(data, mockRuns);
+  console.log('✅ /ps/runs list workflow runs works');
+})();


### PR DESCRIPTION
## Summary
- list existing runs in backend `/ps/runs` endpoint
- add "Load Runs" button and dropdown on the front-end
- auto-fill run id when selecting a run
- cover new route with test

## Testing
- `npm install` *(fails: network access blocked)*
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688373b4d4d0832aa97bd6cecaff59ee