### PR TITLE
Add crypto ticker mapping utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/tests/dataAggregator.test.js
+++ b/tests/dataAggregator.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const {
+  mapTicker,
+  isCryptoTicker
+} = require('../utils/dataAggregator');
+
+// mapTicker crypto cases
+const xrp = mapTicker('XRP');
+assert.deepStrictEqual(xrp, { type: 'crypto', coingeckoId: 'ripple', symbol: 'XRP' });
+
+const doge = mapTicker('doge');
+assert.deepStrictEqual(doge, { type: 'crypto', coingeckoId: 'dogecoin', symbol: 'DOGE' });
+
+// mapTicker non-crypto
+const nas = mapTicker('NAS100');
+assert.deepStrictEqual(nas, { type: 'traditional', polygonSymbol: 'NAS100' });
+
+// isCryptoTicker
+assert.strictEqual(isCryptoTicker('XRP'), true);
+assert.strictEqual(isCryptoTicker('NAS100'), false);
+
+console.log('✅ dataAggregator crypto mapping works');

--- a/utils/dataAggregator.js
+++ b/utils/dataAggregator.js
@@ -1,0 +1,71 @@
+const CRYPTO_TICKERS = {
+  XRP: 'ripple',
+  DOGE: 'dogecoin'
+};
+
+function mapTicker(ticker) {
+  const upper = ticker.toUpperCase();
+  if (CRYPTO_TICKERS[upper]) {
+    return { type: 'crypto', coingeckoId: CRYPTO_TICKERS[upper], symbol: upper };
+  }
+  // For now, simply treat non-crypto tickers as traditional assets
+  return { type: 'traditional', polygonSymbol: ticker.toUpperCase() };
+}
+
+function isCryptoTicker(ticker) {
+  return Object.prototype.hasOwnProperty.call(CRYPTO_TICKERS, ticker.toUpperCase());
+}
+
+function getCoinGeckoId(ticker) {
+  return CRYPTO_TICKERS[ticker.toUpperCase()] || null;
+}
+
+async function fetchCryptoOHLCData(/* coingeckoId */) {
+  // Placeholder for crypto OHLC fetching logic to be implemented later
+  return null;
+}
+
+async function fetchCryptoTechnicalIndicators(/* coingeckoId */) {
+  // Placeholder for crypto indicators fetching logic to be implemented later
+  return null;
+}
+
+async function fetchTraditionalOHLCData(/* polygonSymbol */) {
+  // Placeholder for existing traditional market data fetching
+  return null;
+}
+
+async function fetchTraditionalTechnicalIndicators(/* polygonSymbol */) {
+  // Placeholder for existing technical indicator fetching
+  return null;
+}
+
+async function fetchOHLCData(ticker) {
+  const { type, coingeckoId, polygonSymbol } = mapTicker(ticker);
+  if (type === 'crypto') {
+    return fetchCryptoOHLCData(coingeckoId);
+  }
+  return fetchTraditionalOHLCData(polygonSymbol);
+}
+
+async function fetchTechnicalIndicators(ticker) {
+  const { type, coingeckoId, polygonSymbol } = mapTicker(ticker);
+  if (type === 'crypto') {
+    return fetchCryptoTechnicalIndicators(coingeckoId);
+  }
+  return fetchTraditionalTechnicalIndicators(polygonSymbol);
+}
+
+module.exports = {
+  CRYPTO_TICKERS,
+  mapTicker,
+  isCryptoTicker,
+  getCoinGeckoId,
+  fetchOHLCData,
+  fetchTechnicalIndicators,
+  // Export placeholders for completeness/testing
+  fetchCryptoOHLCData,
+  fetchCryptoTechnicalIndicators,
+  fetchTraditionalOHLCData,
+  fetchTraditionalTechnicalIndicators
+};


### PR DESCRIPTION
## Summary
- extend ticker mapping utilities
- add dataAggregator utilities for crypto support
- create tests validating ticker mapping
- update npm test script to run new tests first

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688406543318832abaa1f6f8abf441f8