### PR TITLE
Implement navigation and placeholder screens

### DIFF
--- a/sow-mobile/App.tsx
+++ b/sow-mobile/App.tsx
@@ -1,9 +1,10 @@
-import { Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import RootNavigator from './src/navigation/RootNavigator';
 
 export default function App() {
   return (
-    <View className="flex-1 items-center justify-center bg-white">
-      <Text className="text-lg font-bold text-blue-600">🚀 SOW Generator App</Text>
-    </View>
+    <SafeAreaView className="flex-1 bg-white">
+      <RootNavigator />
+    </SafeAreaView>
   );
 }

--- a/sow-mobile/src/navigation/RootNavigator.tsx
+++ b/sow-mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import HomeScreen from '../screens/HomeScreen';
+import UploadScreen from '../screens/UploadScreen';
+import TaskListScreen from '../screens/TaskListScreen';
+import MarkdownPreviewScreen from '../screens/MarkdownPreviewScreen';
+import BrandingScreen from '../screens/BrandingScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Upload: undefined;
+  Tasks: undefined;
+  Preview: undefined;
+  Branding: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Upload" component={UploadScreen} />
+        <Stack.Screen name="Tasks" component={TaskListScreen} />
+        <Stack.Screen name="Preview" component={MarkdownPreviewScreen} />
+        <Stack.Screen name="Branding" component={BrandingScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/sow-mobile/src/screens/BrandingScreen.tsx
+++ b/sow-mobile/src/screens/BrandingScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function BrandingScreen() {
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-xl font-bold mb-4">Branding Assets Screen</Text>
+    </View>
+  );
+}

--- a/sow-mobile/src/screens/HomeScreen.tsx
+++ b/sow-mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,15 @@
+import { View, Text, Button } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../navigation/RootNavigator';
+
+export default function HomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-xl font-bold mb-4">🏠 Home Screen</Text>
+      <Button title="Upload BRD" onPress={() => navigation.navigate('Upload')} />
+    </View>
+  );
+}

--- a/sow-mobile/src/screens/MarkdownPreviewScreen.tsx
+++ b/sow-mobile/src/screens/MarkdownPreviewScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function MarkdownPreviewScreen() {
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-xl font-bold mb-4">Preview Screen</Text>
+    </View>
+  );
+}

--- a/sow-mobile/src/screens/TaskListScreen.tsx
+++ b/sow-mobile/src/screens/TaskListScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function TaskListScreen() {
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-xl font-bold mb-4">Task List Screen</Text>
+    </View>
+  );
+}

--- a/sow-mobile/src/screens/UploadScreen.tsx
+++ b/sow-mobile/src/screens/UploadScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function UploadScreen() {
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-xl font-bold mb-4">Upload BRD Screen</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- setup React Navigation with a root navigator
- wire up App.tsx to use the navigator
- add five placeholder screens (Home, Upload, Task List, Preview, Branding)

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68875aa1c2cc832a83f25ca4305b6fff