### PR TITLE
Add file picker for BRD uploads

### DIFF
--- a/sow-mobile/package.json
+++ b/sow-mobile/package.json
@@ -23,7 +23,8 @@
     "react-native-screens": "~3.22.0",
     "react-native-gesture-handler": "~2.12.0",
     "react-query": "^3.39.3",
-    "axios": "^1.5.0"
+    "axios": "^1.5.0",
+    "expo-document-picker": "~15.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/sow-mobile/src/screens/UploadScreen.tsx
+++ b/sow-mobile/src/screens/UploadScreen.tsx
@@ -1,32 +1,58 @@
-import { View, Text, TextInput, FlatList, ActivityIndicator } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { useState } from 'react';
-import { useBRDRuns } from '../hooks/useBRDRuns';
+import * as DocumentPicker from 'expo-document-picker';
+import { uploadBRDFile } from '../services/api';
 
 export default function UploadScreen() {
-  const [templateId, setTemplateId] = useState('');
-  const { data, isLoading, error } = useBRDRuns(templateId);
+  const [file, setFile] = useState<any>(null);
+  const [uploading, setUploading] = useState(false);
+  const [serverResponse, setServerResponse] = useState('');
+
+  const pickFile = async () => {
+    const result = await DocumentPicker.getDocumentAsync({
+      type: ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+    });
+
+    if (result.type === 'success') {
+      setFile(result);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    try {
+      setUploading(true);
+      const response = await uploadBRDFile(file);
+      setServerResponse(response?.message || 'Uploaded successfully!');
+    } catch (err) {
+      setServerResponse('Upload failed.');
+      console.error(err);
+    } finally {
+      setUploading(false);
+    }
+  };
 
   return (
     <View className="flex-1 p-4 bg-white">
-      <Text className="text-lg font-bold mb-2">Fetch BRD Runs</Text>
-      <TextInput
-        className="border p-2 mb-4"
-        placeholder="Enter Template ID"
-        value={templateId}
-        onChangeText={setTemplateId}
-      />
-      {isLoading && <ActivityIndicator />}
-      {error && <Text className="text-red-500">Error loading runs</Text>}
-      <FlatList
-        data={data}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <View className="p-2 border-b">
-            <Text className="font-semibold">{item.name}</Text>
-            <Text className="text-xs text-gray-500">{item.id}</Text>
-          </View>
-        )}
-      />
+      <Text className="text-xl font-bold mb-4">📤 Upload BRD File</Text>
+
+      <TouchableOpacity onPress={pickFile} className="bg-indigo-500 p-3 rounded mb-4">
+        <Text className="text-white text-center font-semibold">Choose File</Text>
+      </TouchableOpacity>
+
+      {file && <Text className="mb-2 text-sm">{file.name}</Text>}
+
+      <TouchableOpacity
+        onPress={handleUpload}
+        disabled={!file || uploading}
+        className={`p-3 rounded ${uploading ? 'bg-gray-400' : 'bg-green-600'}`}
+      >
+        <Text className="text-white text-center font-semibold">
+          {uploading ? 'Uploading...' : 'Upload File'}
+        </Text>
+      </TouchableOpacity>
+
+      {!!serverResponse && <Text className="mt-4 text-center">{serverResponse}</Text>}
     </View>
   );
 }

--- a/sow-mobile/src/services/api.ts
+++ b/sow-mobile/src/services/api.ts
@@ -9,3 +9,20 @@ export const api = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+export async function uploadBRDFile(file: any) {
+  const formData = new FormData();
+  formData.append('brdFile', {
+    uri: file.uri,
+    name: file.name,
+    type: file.mimeType || 'application/octet-stream',
+  } as any);
+
+  const response = await api.post('/upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- add expo-document-picker dependency
- implement API helper to upload BRD file with FormData
- update UploadScreen to allow picking and uploading PDF/Docx files

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688760e74d94832a8c19fb270a65cf5f