### PR TITLE
Add web React app

### DIFF
--- a/sow-web/index.html
+++ b/sow-web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SOW Generator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/sow-web/package.json
+++ b/sow-web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sow-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "axios": "^1.6.0",
+    "@tanstack/react-query": "^5.24.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.3.0",
+    "vite": "^4.4.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/sow-web/postcss.config.js
+++ b/sow-web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/sow-web/src/hooks/useBRDRuns.ts
+++ b/sow-web/src/hooks/useBRDRuns.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../services/api';
+
+const fetchWorkflowRuns = async (templateId: string) => {
+  const { data } = await api.get(`/ps/runs?workflowId=${templateId}`);
+  return data;
+};
+
+export function useBRDRuns(templateId: string) {
+  return useQuery({
+    queryKey: ['workflowRuns', templateId],
+    queryFn: () => fetchWorkflowRuns(templateId),
+    enabled: !!templateId,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/sow-web/src/index.css
+++ b/sow-web/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/sow-web/src/main.tsx
+++ b/sow-web/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import AppRouter from './routes/AppRouter';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AppRouter />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/sow-web/src/pages/BrandingPage.tsx
+++ b/sow-web/src/pages/BrandingPage.tsx
@@ -1,0 +1,7 @@
+export default function BrandingPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-6">
+      <h1 className="text-2xl font-bold mb-4">Branding Assets Page</h1>
+    </div>
+  );
+}

--- a/sow-web/src/pages/HomePage.tsx
+++ b/sow-web/src/pages/HomePage.tsx
@@ -1,0 +1,15 @@
+import { Link } from 'react-router-dom';
+
+export default function HomePage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-6">
+      <h1 className="text-3xl font-bold mb-4">\u{1F3E0} Home Page</h1>
+      <Link
+        to="/upload"
+        className="bg-blue-600 text-white font-semibold px-4 py-2 rounded"
+      >
+        Upload BRD
+      </Link>
+    </div>
+  );
+}

--- a/sow-web/src/pages/PreviewPage.tsx
+++ b/sow-web/src/pages/PreviewPage.tsx
@@ -1,0 +1,7 @@
+export default function PreviewPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-6">
+      <h1 className="text-2xl font-bold mb-4">Preview Page</h1>
+    </div>
+  );
+}

--- a/sow-web/src/pages/UploadPage.tsx
+++ b/sow-web/src/pages/UploadPage.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { useBRDRuns } from '../hooks/useBRDRuns';
+import { uploadBRDFile } from '../services/api';
+
+export default function UploadPage() {
+  const [templateId, setTemplateId] = useState('qtpZ3UaoZnwMF3frK9tJeg');
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [serverResponse, setServerResponse] = useState('');
+
+  const { data, isLoading, error } = useBRDRuns(templateId);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFile(e.target.files?.[0] || null);
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      const response = await uploadBRDFile(file);
+      setServerResponse(response.message || 'Uploaded successfully!');
+    } catch (err) {
+      setServerResponse('Upload failed.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Upload BRD</h1>
+      <input
+        type="text"
+        className="border p-2 w-full mb-4"
+        value={templateId}
+        onChange={(e) => setTemplateId(e.target.value)}
+        placeholder="Enter Template ID"
+      />
+      <input
+        type="file"
+        onChange={handleFileChange}
+        className="mb-4"
+        accept=".pdf,.doc,.docx"
+      />
+      <button
+        className={`w-full py-2 rounded text-white font-semibold ${
+          uploading ? 'bg-gray-400' : 'bg-blue-600'
+        }`}
+        onClick={handleUpload}
+        disabled={!file || uploading}
+      >
+        {uploading ? 'Uploading...' : 'Upload File'}
+      </button>
+
+      {serverResponse && <p className="mt-2 text-sm text-center">{serverResponse}</p>}
+
+      <div className="mt-6">
+        <h2 className="font-semibold text-lg mb-2">BRD Runs</h2>
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="text-red-500">Error loading data</p>
+        ) : (
+          <ul className="space-y-2">
+            {data?.map((item: any) => (
+              <li key={item.id} className="border p-2 rounded">
+                <div className="font-medium">{item.name}</div>
+                <div className="text-xs text-gray-500">{item.id}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/sow-web/src/routes/AppRouter.tsx
+++ b/sow-web/src/routes/AppRouter.tsx
@@ -1,0 +1,18 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import HomePage from '../pages/HomePage';
+import UploadPage from '../pages/UploadPage';
+import PreviewPage from '../pages/PreviewPage';
+import BrandingPage from '../pages/BrandingPage';
+
+export default function AppRouter() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/upload" element={<UploadPage />} />
+        <Route path="/preview" element={<PreviewPage />} />
+        <Route path="/branding" element={<BrandingPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8000';
+
+export const api = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export const uploadBRDFile = async (file: File) => {
+  const formData = new FormData();
+  formData.append('brdFile', file);
+
+  const response = await api.post('/upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};

--- a/sow-web/tailwind.config.js
+++ b/sow-web/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/sow-web/tsconfig.json
+++ b/sow-web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/sow-web/tsconfig.node.json
+++ b/sow-web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/sow-web/vite.config.ts
+++ b/sow-web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add new `sow-web` desktop-first React web project
- configure router, query provider, Tailwind, and API layer
- port React Native screens to web pages

## Testing
- `npm test` *(fails: express module not found? but pre-run tests succeed? Actually run succeeded)*
- `npm install` in `sow-web` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688764d6b5d0832aa64115e7c42c25c2