### PR TITLE
Fix home emoji rendering in HomePage

### DIFF
--- a/sow-web/src/pages/HomePage.tsx
+++ b/sow-web/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 export default function HomePage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-6">
-      <h1 className="text-3xl font-bold mb-4">\u{1F3E0} Home Page</h1>
+      <h1 className="text-3xl font-bold mb-4">🏠 Home Page</h1>
       <Link
         to="/upload"
         className="bg-blue-600 text-white font-semibold px-4 py-2 rounded"


### PR DESCRIPTION
## Summary
- fix the HomePage header text so the emoji renders correctly

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'babel__core')*

------
https://chatgpt.com/codex/tasks/task_e_6888a1dc2a58832a955c68b1b1f46fb8