### PR TITLE
Fix ESM module warning

### DIFF
--- a/sow-web/package.json
+++ b/sow-web/package.json
@@ -2,6 +2,7 @@
   "name": "sow-web",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- explicitly mark sow-web package as an ES module

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888a6b15ffc832aad96a37ee2cd9b70