### PR TITLE
Fix missing favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SOW Generator - File Uploader</title>
+    <link rel="icon" href="data:," />
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/reveal.js/dist/reveal.css">
     <link rel="stylesheet" href="https://unpkg.com/reveal.js/dist/theme/black.css">

--- a/sow-web/index.html
+++ b/sow-web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SOW Generator</title>
+    <link rel="icon" href="data:," />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add a default inline favicon on both index files to avoid 404 errors

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888a9249888832a812d5c90afa45579