### PR TITLE
Add Markdown run viewer

### DIFF
--- a/sow-web/src/pages/RunMarkdownPage.tsx
+++ b/sow-web/src/pages/RunMarkdownPage.tsx
@@ -1,0 +1,60 @@
+import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+export default function RunMarkdownPage() {
+  const { runId } = useParams<{ runId: string }>();
+  const [markdown, setMarkdown] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchMarkdown = async () => {
+      if (!runId) return;
+      try {
+        const { data: tasks } = await api.get(`/ps/tasks/${runId}`);
+        let combined = '';
+        for (const task of tasks) {
+          const { data } = await api.get(`/ps/tasks/${runId}/${task.id}`, { responseType: 'text' });
+          const taskName = task.name || `Task ${task.id}`;
+          combined += `## ${taskName}\n\n${data}\n\n`;
+        }
+        setMarkdown(combined.trim());
+      } catch (err: any) {
+        setError('Error loading tasks');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMarkdown();
+  }, [runId]);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(markdown);
+  };
+
+  if (loading) {
+    return <div className="p-6">Loading...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-500">{error}</div>;
+  }
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Run Markdown</h1>
+      <textarea
+        className="w-full border p-2 h-96 mb-4"
+        value={markdown}
+        onChange={(e) => setMarkdown(e.target.value)}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+        onClick={handleCopy}
+      >
+        Copy Markdown
+      </button>
+    </div>
+  );
+}

--- a/sow-web/src/pages/UploadPage.tsx
+++ b/sow-web/src/pages/UploadPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useBRDRuns } from '../hooks/useBRDRuns';
 import { uploadBRDFile } from '../services/api';
 
@@ -65,8 +66,10 @@ export default function UploadPage() {
           <ul className="space-y-2">
             {data?.map((item: any) => (
               <li key={item.id} className="border p-2 rounded">
-                <div className="font-medium">{item.name}</div>
-                <div className="text-xs text-gray-500">{item.id}</div>
+                <Link to={`/run/${item.id}`} className="block">
+                  <div className="font-medium">{item.name}</div>
+                  <div className="text-xs text-gray-500">{item.id}</div>
+                </Link>
               </li>
             ))}
           </ul>

--- a/sow-web/src/routes/AppRouter.tsx
+++ b/sow-web/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import HomePage from '../pages/HomePage';
 import UploadPage from '../pages/UploadPage';
 import PreviewPage from '../pages/PreviewPage';
 import BrandingPage from '../pages/BrandingPage';
+import RunMarkdownPage from '../pages/RunMarkdownPage';
 
 export default function AppRouter() {
   return (
@@ -12,6 +13,7 @@ export default function AppRouter() {
         <Route path="/upload" element={<UploadPage />} />
         <Route path="/preview" element={<PreviewPage />} />
         <Route path="/branding" element={<BrandingPage />} />
+        <Route path="/run/:runId" element={<RunMarkdownPage />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary
- create `RunMarkdownPage` for viewing tasks as Markdown
- link BRD run list to the new page
- register page in router

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888ae9b20b4832abba0f616b55ee8c4