### PR TITLE
Fix Markdown output for Process Street task fields

### DIFF
--- a/server.js
+++ b/server.js
@@ -1073,7 +1073,14 @@ app.get('/ps/tasks/:runId/:taskId', async (req, res) => {
     const md = allFields.map(f => {
       const label = f.label || f.key;
       const data  = f.data;
-      const val = Array.isArray(data) ? data.join(', ') : String(data);
+      let val;
+      if (Array.isArray(data)) {
+        val = data.join(', ');
+      } else if (data && typeof data === 'object') {
+        val = JSON.stringify(data);
+      } else {
+        val = String(data);
+      }
       return `**${label}:** ${val}`;
     }).join('\n\n');
 


### PR DESCRIPTION
## Summary
- ensure `GET /ps/tasks/:runId/:taskId` outputs form-field data even when the value is an object

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888b2ca3354832a8c888f5f324cc68a