### PR TITLE
Add SOW generation button

### DIFF
--- a/server.js
+++ b/server.js
@@ -1203,6 +1203,22 @@ app.post('/upload', async (req, res) => {
     }
 });
 
+// Endpoint to run the agentic workflow on raw markdown text
+app.post('/generate-sow', async (req, res) => {
+    try {
+        const { markdown } = req.body || {};
+        if (!markdown) {
+            return res.status(400).json({ message: 'No markdown provided' });
+        }
+
+        const generated = await sowOrchestrator(markdown, brandContext);
+        res.status(200).json({ markdown: generated });
+    } catch (error) {
+        console.error('Error generating SOW from markdown:', error);
+        res.status(500).json({ message: 'Failed to generate SOW' });
+    }
+});
+
 // --- Export Endpoints ---
 app.post('/export/pdf', async (req, res) => {
     try {

--- a/sow-web/src/pages/GeneratedSowPage.tsx
+++ b/sow-web/src/pages/GeneratedSowPage.tsx
@@ -1,0 +1,23 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
+export default function GeneratedSowPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const initial = (location.state as any)?.markdown || '';
+  const [markdown, setMarkdown] = useState(initial);
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <button className="text-blue-600" onClick={() => navigate(-1)}>&larr; Back</button>
+        <h1 className="text-2xl font-bold">Generated SOW</h1>
+      </div>
+      <textarea
+        className="w-full border p-2 h-96 mb-4"
+        value={markdown}
+        onChange={(e) => setMarkdown(e.target.value)}
+      />
+    </div>
+  );
+}

--- a/sow-web/src/pages/RunMarkdownPage.tsx
+++ b/sow-web/src/pages/RunMarkdownPage.tsx
@@ -1,9 +1,10 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { api } from '../services/api';
+import { api, generateSow } from '../services/api';
 
 export default function RunMarkdownPage() {
   const { runId } = useParams<{ runId: string }>();
+  const navigate = useNavigate();
   const [markdown, setMarkdown] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -33,6 +34,19 @@ export default function RunMarkdownPage() {
     navigator.clipboard.writeText(markdown);
   };
 
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  const handleGenerate = async () => {
+    try {
+      const { markdown: newMarkdown } = await generateSow(markdown);
+      navigate('/generated', { state: { markdown: newMarkdown } });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   if (loading) {
     return <div className="p-6">Loading...</div>;
   }
@@ -43,18 +57,29 @@ export default function RunMarkdownPage() {
 
   return (
     <div className="p-6 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Run Markdown</h1>
+      <div className="flex items-center justify-between mb-4">
+        <button className="text-blue-600" onClick={handleBack}>&larr; Back</button>
+        <h1 className="text-2xl font-bold">Run Markdown</h1>
+      </div>
       <textarea
         className="w-full border p-2 h-96 mb-4"
         value={markdown}
         onChange={(e) => setMarkdown(e.target.value)}
       />
-      <button
-        className="px-4 py-2 bg-blue-600 text-white rounded"
-        onClick={handleCopy}
-      >
-        Copy Markdown
-      </button>
+      <div className="space-x-2">
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={handleCopy}
+        >
+          Copy Markdown
+        </button>
+        <button
+          className="px-4 py-2 bg-green-600 text-white rounded"
+          onClick={handleGenerate}
+        >
+          Generate SOW
+        </button>
+      </div>
     </div>
   );
 }

--- a/sow-web/src/routes/AppRouter.tsx
+++ b/sow-web/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import UploadPage from '../pages/UploadPage';
 import PreviewPage from '../pages/PreviewPage';
 import BrandingPage from '../pages/BrandingPage';
 import RunMarkdownPage from '../pages/RunMarkdownPage';
+import GeneratedSowPage from '../pages/GeneratedSowPage';
 
 export default function AppRouter() {
   return (
@@ -13,6 +14,7 @@ export default function AppRouter() {
         <Route path="/preview" element={<PreviewPage />} />
         <Route path="/branding" element={<BrandingPage />} />
         <Route path="/run/:runId" element={<RunMarkdownPage />} />
+        <Route path="/generated" element={<GeneratedSowPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -22,3 +22,8 @@ export const uploadBRDFile = async (file: File) => {
 
   return response.data;
 };
+
+export const generateSow = async (markdown: string) => {
+  const response = await api.post('/generate-sow', { markdown });
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- add API endpoint to generate SOW from markdown
- expose generateSow client function
- insert back button and generate button on RunMarkdownPage
- add GeneratedSowPage to show new markdown
- register new route

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888b3d7c274832aa37d2ff03acb2cb4