### PR TITLE
Fix API timeout for long generation

### DIFF
--- a/sow-mobile/src/services/api.ts
+++ b/sow-mobile/src/services/api.ts
@@ -4,7 +4,7 @@ const API_BASE_URL = 'http://localhost:8000'; // Replace with your actual IP if 
 
 export const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 180000,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -4,7 +4,7 @@ const API_BASE_URL = 'http://localhost:8000';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 10000,
+  timeout: 180000,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- increase Axios timeout to three minutes for slow agentic workflow

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888b9677020832a9bd5960dc50d854e