### PR TITLE
Increase axios timeout

### DIFF
--- a/sow-mobile/src/services/api.ts
+++ b/sow-mobile/src/services/api.ts
@@ -4,7 +4,7 @@ const API_BASE_URL = 'http://localhost:8000'; // Replace with your actual IP if 
 
 export const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 180000,
+  timeout: 600000,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -4,7 +4,7 @@ const API_BASE_URL = 'http://localhost:8000';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 180000,
+  timeout: 600000,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Summary
- update Axios timeout for mobile and web clients to 10 minutes

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6888c850db0c832abb095e6b6be68990