### PR TITLE
Add Together.ai API wrapper and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Create a `.env` file with the following entries:
 ```
 GEMINI_API_KEY=<your gemini key>
 PS_API_KEY=<your process street api key>
+TOGETHER_API_KEY=<your together.ai key>
+# Optional override
+TOGETHER_API_BASE=https://api.together.ai
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.

--- a/config/aiConfig.js
+++ b/config/aiConfig.js
@@ -1,0 +1,14 @@
+// Loads and validates configuration for Together.ai credentials.
+const assert = require('assert');
+
+const TOGETHER_API_KEY = process.env.TOGETHER_API_KEY;
+const TOGETHER_API_BASE = process.env.TOGETHER_API_BASE || 'https://api.together.ai';
+
+assert(TOGETHER_API_KEY, 'Missing TOGETHER_API_KEY in environment');
+
+module.exports = {
+  together: {
+    apiKey: TOGETHER_API_KEY,
+    base: TOGETHER_API_BASE,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/aiProvider.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -21,6 +21,8 @@ const pdf = require('pdf-parse');
 const { mdToPdf } = require('md-to-pdf');
 const PPTX = require('pptxgenjs');
 const { brandContext } = require('./config/brandContext');
+const { generateWithFallback } = require('./services/aiProvider');
+const { logAiUsage } = require('./utils/logging');
 
 // 2. Initialize Express App & Gemini AI
 const app = express();
@@ -388,7 +390,10 @@ async function essentialInfoAgent(data) {
     ${JSON.stringify(data, null, 2)}
     """
 `;
-    return await generateContentWithRetry(prompt);
+    const start = Date.now();
+    const { text, source } = await generateWithFallback(prompt);
+    logAiUsage({ prompt, source, duration: Date.now() - start, outputLength: text.length });
+    return text;
 }
 
 /**

--- a/services/aiProvider.js
+++ b/services/aiProvider.js
@@ -1,0 +1,33 @@
+/**
+ * Provider-agnostic AI interface. Tries Together.ai first and falls
+ * back to Gemini on failure. Exposes generateWithFallback and
+ * editWithFallback for use by agents.
+ */
+const { callCompletion, callChatCompletion } = require('./togetherClient');
+const { generateContentWithRetry: geminiGenerate } = require('./geminiWrapper');
+
+async function generateWithFallback(prompt, options = {}) {
+  try {
+    const text = await callCompletion({ prompt, ...options });
+    return { source: 'together', text };
+  } catch (err) {
+    console.warn('[AIProvider] Together.ai failed, falling back to Gemini:', err.message);
+    const text = await geminiGenerate(prompt);
+    return { source: 'gemini', text };
+  }
+}
+
+async function editWithFallback(messages, options = {}) {
+  try {
+    const text = await callChatCompletion({ messages, ...options });
+    return { source: 'together', text };
+  } catch (err) {
+    console.warn('[AIProvider] Together.ai chat edit failed, falling back to Gemini');
+    const lastUser = messages.filter(m => m.role === 'user').slice(-1)[0];
+    const prompt = lastUser ? lastUser.content : '';
+    const text = await geminiGenerate(prompt);
+    return { source: 'gemini', text };
+  }
+}
+
+module.exports = { generateWithFallback, editWithFallback };

--- a/services/geminiWrapper.js
+++ b/services/geminiWrapper.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const { GoogleGenerativeAI } = require('@google/generative-ai');
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+assert(GEMINI_API_KEY, 'Missing GEMINI_API_KEY in environment');
+
+const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+
+async function generateContentWithRetry(prompt, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const result = await model.generateContent(prompt);
+      return result.response.text();
+    } catch (error) {
+      console.warn(`Gemini attempt ${i + 1} failed.`, error.message);
+      if (i === retries - 1) {
+        throw error;
+      }
+      await new Promise(res => setTimeout(res, 1500));
+    }
+  }
+}
+
+module.exports = { generateContentWithRetry };

--- a/services/togetherClient.js
+++ b/services/togetherClient.js
@@ -1,0 +1,98 @@
+/**
+ * Together.ai API wrapper providing completion and chat APIs with
+ * exponential backoff retry logic. Requires TOGETHER_API_KEY and
+ * optional TOGETHER_API_BASE environment variables which are loaded
+ * in ../config/aiConfig.js.
+ */
+const fetch = (...args) => global.fetch(...args);
+const { together } = require('../config/aiConfig');
+
+const DEFAULT_MODEL = 'codellama/CodeLlama-34b-Instruct-hf';
+
+async function retryWithBackoff(fn, { retries = 3, baseDelay = 500 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const last = attempt === retries;
+      console.warn(`[TogetherClient] Attempt ${attempt + 1} failed${last ? ' (giving up)' : ''}:`, err.message);
+      if (last) throw err;
+      const backoff = baseDelay * Math.pow(2, attempt) + Math.random() * 100;
+      await new Promise(res => setTimeout(res, backoff));
+    }
+  }
+}
+
+function buildHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${together.apiKey}`,
+  };
+}
+
+async function callCompletion({
+  model = DEFAULT_MODEL,
+  prompt,
+  max_tokens = 1500,
+  temperature = 0.7,
+  stop = null,
+}) {
+  if (!prompt) throw new Error('Prompt is required for callCompletion');
+
+  const body = { model, prompt, max_tokens, temperature };
+  if (stop) body.stop = stop;
+
+  const fn = async () => {
+    const res = await fetch(`${together.base}/v1/completions`, {
+      method: 'POST',
+      headers: buildHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Together.ai completion error: ${res.status} - ${text}`);
+    }
+    const data = await res.json();
+    if (!data.choices || !data.choices[0]) {
+      throw new Error('Malformed Together.ai completion response');
+    }
+    return data.choices[0].text;
+  };
+
+  return retryWithBackoff(fn);
+}
+
+async function callChatCompletion({
+  model = DEFAULT_MODEL,
+  messages,
+  max_tokens = 1500,
+  temperature = 0.7,
+  stream = false,
+}) {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error('Messages array required for chat completion');
+  }
+
+  const body = { model, messages, max_tokens, temperature, stream };
+
+  const fn = async () => {
+    const res = await fetch(`${together.base}/v1/chat/completions`, {
+      method: 'POST',
+      headers: buildHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Together.ai chat error: ${res.status} - ${text}`);
+    }
+    const data = await res.json();
+    if (!data.choices || !data.choices[0]?.message?.content) {
+      throw new Error('Malformed Together.ai chat response');
+    }
+    return data.choices[0].message.content;
+  };
+
+  return retryWithBackoff(fn);
+}
+
+module.exports = { callCompletion, callChatCompletion };

--- a/tests/aiProvider.test.js
+++ b/tests/aiProvider.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 'test';
+process.env.GEMINI_API_KEY = 'gem';
+
+// Mock togetherClient to fail
+const togetherMock = {
+  callCompletion: async () => { throw new Error('fail'); },
+  callChatCompletion: async () => { throw new Error('fail'); },
+};
+require.cache[require.resolve('../services/togetherClient')] = { exports: togetherMock };
+
+// Mock gemini wrapper to return success
+const geminiMock = {
+  generateContentWithRetry: async (p) => `gem:${p}`,
+};
+require.cache[require.resolve('../services/geminiWrapper')] = { exports: geminiMock };
+
+const { generateWithFallback, editWithFallback } = require('../services/aiProvider');
+
+(async () => {
+  const g = await generateWithFallback('hi');
+  assert.deepStrictEqual(g, { source: 'gemini', text: 'gem:hi' });
+
+  const c = await editWithFallback([{ role: 'user', content: 'u' }]);
+  assert.deepStrictEqual(c, { source: 'gemini', text: 'gem:u' });
+  console.log('✅ aiProvider falls back to gemini');
+})().catch(err => { console.error(err); process.exit(1); });

--- a/tests/togetherClient.test.js
+++ b/tests/togetherClient.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 'test';
+
+let callCount = 0;
+
+global.fetch = async () => {
+  callCount += 1;
+  if (callCount === 1) {
+    return { ok: false, status: 500, text: async () => 'err' };
+  }
+  return { ok: true, json: async () => ({ choices: [{ text: 'ok' }] }) };
+};
+
+const { callCompletion } = require('../services/togetherClient');
+
+(async () => {
+  const res = await callCompletion({ prompt: 'test', max_tokens: 5 });
+  assert.strictEqual(res, 'ok');
+  assert.strictEqual(callCount, 2);
+  console.log('✅ togetherClient retries and succeeds');
+})().catch(err => { console.error(err); process.exit(1); });

--- a/utils/logging.js
+++ b/utils/logging.js
@@ -1,0 +1,11 @@
+const crypto = require('crypto');
+
+function hash(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function logAiUsage({ prompt, source, duration, outputLength }) {
+  console.info(`[AI] PromptHash=${hash(prompt)} Source=${source} DurationMs=${duration} OutputLength=${outputLength}`);
+}
+
+module.exports = { hash, logAiUsage };


### PR DESCRIPTION
## Summary
- load Together.ai credentials from environment
- implement retrying Together.ai client
- provide Gemini fallback interface
- add logging helper
- wire Pages & Tech agent to new provider
- document new environment variables
- test Together.ai client and fallback logic

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b3c35438c832aab45a9b056d07343