### PR TITLE
Add slide generator service

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js"
   },
   "author": "",
   "license": "ISC",
@@ -18,8 +18,8 @@
     "google-auth-library": "^9.11.0",
     "googleapis": "^137.1.0",
     "mammoth": "^1.7.2",
-    "pdf-parse": "^1.1.1",
     "md-to-pdf": "^5.1.0",
+    "pdf-parse": "^1.1.1",
     "pptxgenjs": "^3.9.0"
   }
 }

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const { generateSlidesFromMarkdown } = require('../services/slideGenerator');
+const { brandContext } = require('../config/brandContext');
+
+router.post('/generate', async (req, res) => {
+  try {
+    const { fullSow } = req.body;
+    if (!fullSow) return res.status(400).json({ error: 'fullSow markdown is required' });
+
+    const slides = await generateSlidesFromMarkdown(fullSow, brandContext);
+    res.json({ slides });
+  } catch (err) {
+    console.error('[SlideGeneration] failed', err);
+    res.status(500).json({ error: 'Slide generation failed', detail: err.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const PPTX = require('pptxgenjs');
 const { brandContext } = require('./config/brandContext');
 const { generateWithFallback } = require('./services/aiProvider');
 const { logAiUsage } = require('./utils/logging');
+const slideRoutes = require('./routes/slides');
 
 // 2. Initialize Express App & Gemini AI
 const app = express();
@@ -1004,6 +1005,7 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(fileUpload());
+app.use('/slides', slideRoutes);
 app.get('/brandcontext', (req, res) => {
     res.json(brandContext);
 });

--- a/services/slideGenerator.js
+++ b/services/slideGenerator.js
@@ -1,0 +1,79 @@
+const { generateWithFallback } = require('./aiProvider');
+const { logAiUsage } = require('../utils/logging');
+const crypto = require('crypto');
+
+function makeSlideId(text) {
+  return crypto.createHash('sha1').update(text).digest('hex').slice(0, 8);
+}
+
+function chunkSowMarkdown(fullMarkdown) {
+  const rawSlides = fullMarkdown.split(/\n---\n/);
+  return rawSlides.map(md => {
+    const titleMatch = md.match(/^#{1,3}\s*(.+)$/m);
+    return {
+      id: `slide-${makeSlideId(md)}`,
+      title: titleMatch ? titleMatch[1].trim() : 'Untitled Slide',
+      originalMarkdown: md.trim(),
+      currentHtml: null,
+      versionHistory: [],
+      chatHistory: [],
+    };
+  });
+}
+
+function sanitizeHtmlFragment(html) {
+  if (!html) return '';
+  return html
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+    .replace(/javascript:/gi, '')
+    .replace(/ on\w+="[^"]*"/gi, '');
+}
+
+function buildSlidePrompt(slideMarkdown, brandContext) {
+  return `
+You are a professional presentation designer. Convert the following Markdown content into a single HTML slide. 
+Use Tailwind CSS utility classes for clean, modern styling consistent with the brand. 
+Output only the HTML snippet. Do not include explanations or markdown.
+
+Branding:
+- Brand Name: ${brandContext.brandName}
+- Tagline: ${brandContext.tagline}
+- Primary font: ${brandContext.fonts.primary} (fallback: ${brandContext.fonts.websafe})
+- Primary color: ${brandContext.palette.digitalTide}
+- Use responsive layout and semantic HTML.
+
+Requirements:
+* Headings should be prominent using Tailwind classes (e.g., text-2xl font-bold, mb-4).
+* Lists should be styled with appropriate spacing and custom bullet (you can use icons or styled list markers).
+* Include spacing between sections (e.g., use mb-6, p-4).
+* If the slide contains stakeholder information, format it as a responsive grid.
+* Avoid inline scripts. Only use Tailwind utility classes.
+* Keep markup minimal but visually clear.
+
+Slide content:
+${slideMarkdown}
+  `;
+}
+
+async function generateSlidesFromMarkdown(fullMarkdown, brandContext) {
+  const slides = chunkSowMarkdown(fullMarkdown);
+  for (const slide of slides) {
+    const prompt = buildSlidePrompt(slide.originalMarkdown, brandContext);
+    const start = Date.now();
+    const { text, source } = await generateWithFallback(prompt, { max_tokens: 1500 });
+    const duration = Date.now() - start;
+    const sanitized = sanitizeHtmlFragment(text);
+    slide.versionHistory.push({ html: slide.currentHtml, timestamp: Date.now(), source });
+    slide.currentHtml = sanitized;
+    logAiUsage({ prompt, source, duration, outputLength: (text || '').length });
+    slide.chatHistory.push({ role: 'assistant', content: sanitized });
+  }
+  return slides;
+}
+
+module.exports = {
+  chunkSowMarkdown,
+  sanitizeHtmlFragment,
+  buildSlidePrompt,
+  generateSlidesFromMarkdown,
+};

--- a/tests/slideGenerator.test.js
+++ b/tests/slideGenerator.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 'test';
+process.env.GEMINI_API_KEY = 'gem';
+
+// Mock aiProvider to return simple HTML
+const aiMock = {
+  generateWithFallback: async () => ({ source: 'mock', text: '<h1 class="text-2xl">Title</h1>' })
+};
+require.cache[require.resolve('../services/aiProvider')] = { exports: aiMock };
+
+const { brandContext } = require('../config/brandContext');
+const { generateSlidesFromMarkdown, chunkSowMarkdown, sanitizeHtmlFragment } = require('../services/slideGenerator');
+
+(async () => {
+  const md = '## Slide One\nContent\n\n---\n\n## Slide Two\nMore';
+  const slides = await generateSlidesFromMarkdown(md, brandContext);
+  assert.strictEqual(slides.length, 2);
+  assert.ok(slides[0].currentHtml.includes('text-2xl'));
+  assert.strictEqual(slides[0].versionHistory.length, 1);
+
+  const chunks = chunkSowMarkdown(md);
+  assert.strictEqual(chunks[0].title, 'Slide One');
+
+  const unsafe = '<div onclick="alert(1)">x<script>bad()</script></div>';
+  const clean = sanitizeHtmlFragment(unsafe);
+  assert(!clean.includes('script'));
+  assert(!/onclick/.test(clean));
+  console.log('✅ slideGenerator works');
+})();


### PR DESCRIPTION
## Summary
- create a slideGenerator service for markdown chunking and HTML generation
- expose `/slides/generate` endpoint
- register slide route in `server.js`
- include basic HTML sanitisation
- add unit test

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b401dc00c832aaa96363a58e1f0e3