### PR TITLE
Enable interactive slide editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ TOGETHER_API_BASE=https://api.together.ai
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.
+
+## Slide Editing API
+
+Slides are generated and edited via the `/slides` routes.
+
+* `POST /slides/generate` body `{ fullSow: "markdown" }` → returns an array of slide objects with `id` and `currentHtml`.
+* `POST /slides/:id/edit` body `{ instruction: "Add teal header" }` → updates the slide and returns it.
+* `GET /slides/:id/versions` → lists prior versions of the slide HTML.
+* `POST /slides/:id/revert` body `{ versionIndex: 0 }` → restores a previous version.
+
+Each slide tracks `chatHistory`, `currentHtml`, and `versionHistory` as it is edited.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/routes/slides.js
+++ b/routes/slides.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const { generateSlidesFromMarkdown } = require('../services/slideGenerator');
+const { applySlideEdit, revertSlideToVersion } = require('../services/slideEditor');
 const { brandContext } = require('../config/brandContext');
+
+// Simple in-memory slide store for demo purposes
+const slideStore = new Map();
 
 router.post('/generate', async (req, res) => {
   try {
@@ -9,10 +13,54 @@ router.post('/generate', async (req, res) => {
     if (!fullSow) return res.status(400).json({ error: 'fullSow markdown is required' });
 
     const slides = await generateSlidesFromMarkdown(fullSow, brandContext);
+    slides.forEach(s => slideStore.set(s.id, s));
     res.json({ slides });
   } catch (err) {
     console.error('[SlideGeneration] failed', err);
     res.status(500).json({ error: 'Slide generation failed', detail: err.message });
+  }
+});
+
+// Apply an edit to a slide
+router.post('/:slideId/edit', async (req, res) => {
+  try {
+    const { slideId } = req.params;
+    const { instruction } = req.body;
+    if (!instruction) return res.status(400).json({ error: 'instruction required' });
+
+    const slide = slideStore.get(slideId);
+    if (!slide) return res.status(404).json({ error: 'Slide not found' });
+
+    const updated = await applySlideEdit(slide, instruction);
+    slideStore.set(slideId, updated);
+    res.json({ slide: updated });
+  } catch (err) {
+    console.error('[SlideEdit] failed', err);
+    res.status(500).json({ error: 'Edit failed', detail: err.message });
+  }
+});
+
+// List versions of a slide
+router.get('/:slideId/versions', (req, res) => {
+  const slide = slideStore.get(req.params.slideId);
+  if (!slide) return res.status(404).json({ error: 'Slide not found' });
+  res.json({ versions: slide.versionHistory });
+});
+
+// Revert to an earlier version
+router.post('/:slideId/revert', (req, res) => {
+  try {
+    const { slideId } = req.params;
+    const { versionIndex } = req.body;
+    const slide = slideStore.get(slideId);
+    if (!slide) return res.status(404).json({ error: 'Slide not found' });
+
+    const reverted = revertSlideToVersion(slide, versionIndex);
+    slideStore.set(slideId, reverted);
+    res.json({ slide: reverted });
+  } catch (err) {
+    console.error('[SlideRevert] failed', err);
+    res.status(500).json({ error: 'Revert failed', detail: err.message });
   }
 });
 

--- a/services/slideEditor.js
+++ b/services/slideEditor.js
@@ -1,0 +1,78 @@
+const { editWithFallback, generateWithFallback } = require('./aiProvider');
+const { sanitizeHtmlFragment } = require('./slideGenerator');
+const { logAiUsage } = require('../utils/logging');
+
+function shouldCondense(history) {
+  return Array.isArray(history) && history.length > 8;
+}
+
+async function condenseChatHistoryIfNeeded(slide) {
+  if (!shouldCondense(slide.chatHistory)) return;
+  const earlier = slide.chatHistory.slice(0, -2);
+  const summaryPrompt =
+    'You are an assistant that summarizes a conversation about editing an HTML slide. ' +
+    'Condense the following earlier messages into concise bullet points capturing what was changed or requested.\n' +
+    earlier.map(m => `${m.role}: ${m.content}`).join('\n') +
+    '\nProvide a summary in 3-5 bullets. Output only the bullets.';
+  const { text } = await generateWithFallback(summaryPrompt, { max_tokens: 200 });
+  slide.chatHistory = [
+    { role: 'system', content: `Summary of earlier edits: ${text}`, timestamp: Date.now() },
+    ...slide.chatHistory.slice(-2),
+  ];
+}
+
+function buildEditMessages(slide, userInstruction) {
+  const systemMessage = {
+    role: 'system',
+    content:
+      'You are a slide editor. Given existing HTML and an instruction, output only the updated HTML snippet using Tailwind classes. Do not explain.'
+  };
+
+  const messages = [systemMessage];
+  const summary = slide.chatHistory.find(m => m.role === 'system');
+  if (summary) messages.push(summary);
+  const lastAssistant = slide.chatHistory.slice().reverse().find(m => m.role === 'assistant');
+  if (lastAssistant) messages.push({ role: 'assistant', content: lastAssistant.content });
+  messages.push({
+    role: 'user',
+    content: `Here is the current HTML:\n${slide.currentHtml}\n\nInstruction: ${userInstruction}. Return the full updated HTML slide snippet.`
+  });
+  return messages;
+}
+
+async function applySlideEdit(slide, userInstruction) {
+  await condenseChatHistoryIfNeeded(slide);
+  const messages = buildEditMessages(slide, userInstruction);
+  const start = Date.now();
+  const { text: updatedHtmlRaw, source } = await editWithFallback(messages);
+  const duration = Date.now() - start;
+  const sanitized = sanitizeHtmlFragment(updatedHtmlRaw);
+  slide.versionHistory.push({
+    html: slide.currentHtml,
+    timestamp: Date.now(),
+    source,
+    instruction: userInstruction,
+  });
+  slide.currentHtml = sanitized;
+  slide.chatHistory.push({ role: 'user', content: userInstruction, timestamp: Date.now() });
+  slide.chatHistory.push({ role: 'assistant', content: sanitized, timestamp: Date.now() });
+  logAiUsage({ prompt: userInstruction, source, duration, outputLength: (updatedHtmlRaw || '').length });
+  return slide;
+}
+
+function revertSlideToVersion(slide, versionIndex) {
+  if (versionIndex < 0 || versionIndex >= slide.versionHistory.length) {
+    throw new Error('Invalid version index');
+  }
+  const version = slide.versionHistory[versionIndex];
+  slide.versionHistory.push({
+    html: slide.currentHtml,
+    timestamp: Date.now(),
+    source: 'revert',
+    instruction: `Reverted to version ${versionIndex}`,
+  });
+  slide.currentHtml = version.html;
+  return slide;
+}
+
+module.exports = { applySlideEdit, revertSlideToVersion, buildEditMessages, condenseChatHistoryIfNeeded };

--- a/tests/slideEditor.test.js
+++ b/tests/slideEditor.test.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 'test';
+process.env.GEMINI_API_KEY = 'gem';
+
+// Mock aiProvider functions
+const aiMock = {
+  editWithFallback: async () => ({ source: 'mock', text: '<div onclick="a()">ok</div>' }),
+  generateWithFallback: async () => ({ source: 'mock', text: '• old edit' })
+};
+require.cache[require.resolve('../services/aiProvider')] = { exports: aiMock };
+
+const { applySlideEdit, revertSlideToVersion } = require('../services/slideEditor');
+
+(async () => {
+  const slide = { id:'s1', title:'', originalMarkdown:'', currentHtml:'<p>old</p>', versionHistory:[], chatHistory:[] };
+  const updated = await applySlideEdit(slide, 'change header');
+  assert.strictEqual(updated.currentHtml, '<div >ok</div>');
+  assert.strictEqual(updated.versionHistory.length, 1);
+  assert.strictEqual(updated.chatHistory.length, 2);
+
+  const reverted = revertSlideToVersion(updated, 0);
+  assert.strictEqual(reverted.currentHtml, '<p>old</p>');
+  assert.strictEqual(reverted.versionHistory.length, 2);
+  console.log('✅ slideEditor apply and revert work');
+})();
+
+(async () => {
+  const slide = { id:'s2', title:'', originalMarkdown:'', currentHtml:'<p>x</p>', versionHistory:[], chatHistory:[] };
+  for (let i=0;i<9;i++) slide.chatHistory.push({ role:'user', content:'msg'+i });
+  await applySlideEdit(slide, 'update');
+  assert.strictEqual(slide.chatHistory[0].role, 'system');
+  console.log('✅ slideEditor summarization works');
+})();


### PR DESCRIPTION
## Summary
- support editing slides with new service `slideEditor.js`
- expose `/slides/:id/edit`, `/slides/:id/versions`, and `/slides/:id/revert`
- store slides in-memory when generated
- document slide editing API
- add tests for slide editor logic

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b4d50eb80832ab1a30a7eff3b9228