### PR TITLE
Improve HTML sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mammoth": "^1.7.2",
     "md-to-pdf": "^5.1.0",
     "pdf-parse": "^1.1.1",
+    "sanitize-html": "^2.12.1",
     "pptxgenjs": "^3.9.0"
   }
 }

--- a/services/slideGenerator.js
+++ b/services/slideGenerator.js
@@ -1,6 +1,12 @@
 const { generateWithFallback } = require('./aiProvider');
 const { logAiUsage } = require('../utils/logging');
 const crypto = require('crypto');
+let sanitizeHtml;
+try {
+  sanitizeHtml = require('sanitize-html');
+} catch {
+  sanitizeHtml = null;
+}
 
 function makeSlideId(text) {
   return crypto.createHash('sha1').update(text).digest('hex').slice(0, 8);
@@ -23,6 +29,15 @@ function chunkSowMarkdown(fullMarkdown) {
 
 function sanitizeHtmlFragment(html) {
   if (!html) return '';
+  if (sanitizeHtml) {
+    return sanitizeHtml(html, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+      allowedAttributes: {
+        '*': ['class', 'style', 'href', 'src', 'alt']
+      }
+    });
+  }
+  // Fallback regex-based sanitization if sanitize-html isn't available
   return html
     .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
     .replace(/javascript:/gi, '')


### PR DESCRIPTION
## Summary
- use sanitize-html when available
- allow Tailwind classes while stripping scripts and event handlers
- include sanitize-html dependency

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b41f74d58832a94bf675accda4ee3