### PR TITLE
Add slide editor UI and diff util

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/diff.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/sow-web/src/pages/SlideEditorPage.tsx
+++ b/sow-web/src/pages/SlideEditorPage.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { api } from '../services/api';
+
+interface Slide {
+  id: string;
+  title: string;
+  currentHtml: string;
+  chatHistory: { role: string; content: string }[];
+}
+
+interface DiffPart {
+  value: string;
+  added?: boolean;
+  removed?: boolean;
+}
+
+function diffText(oldStr: string, newStr: string): DiffPart[] {
+  const oldParts = oldStr.split(/(\s+)/).filter(Boolean);
+  const newParts = newStr.split(/(\s+)/).filter(Boolean);
+  const diff: DiffPart[] = [];
+  let i = 0,
+    j = 0;
+  while (i < oldParts.length && j < newParts.length) {
+    if (oldParts[i] === newParts[j]) {
+      diff.push({ value: newParts[j] });
+      i++;
+      j++;
+    } else {
+      diff.push({ value: newParts[j], added: true });
+      diff.push({ value: oldParts[i], removed: true });
+      i++;
+      j++;
+    }
+  }
+  while (j < newParts.length) {
+    diff.push({ value: newParts[j], added: true });
+    j++;
+  }
+  while (i < oldParts.length) {
+    diff.push({ value: oldParts[i], removed: true });
+    i++;
+  }
+  return diff;
+}
+
+export default function SlideEditorPage() {
+  const [slides, setSlides] = useState<Slide[]>([]);
+  const [selected, setSelected] = useState<Slide | null>(null);
+  const [instruction, setInstruction] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [diff, setDiff] = useState<DiffPart[] | null>(null);
+
+  useEffect(() => {
+    const generate = async () => {
+      try {
+        const { data } = await api.post('/slides/generate', { fullSow: '# Slide\nDemo' });
+        setSlides(data.slides);
+        setSelected(data.slides[0]);
+      } catch (err: any) {
+        setError('Failed to load slides');
+      }
+    };
+    generate();
+  }, []);
+
+  const updateSlideInState = (updated: Slide) => {
+    setSlides((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+    setSelected(updated);
+  };
+
+  const applyEdit = async () => {
+    if (!selected) return;
+    setLoading(true);
+    setError('');
+    const previous = selected.currentHtml;
+    try {
+      const res = await api.post(`/slides/${selected.id}/edit`, { instruction });
+      const updated = res.data.slide as Slide;
+      updateSlideInState(updated);
+      setInstruction('');
+      setDiff(diffText(previous, updated.currentHtml));
+    } catch (err) {
+      setError('Edit failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const revertVersion = async (index: number) => {
+    if (!selected) return;
+    setLoading(true);
+    try {
+      const res = await api.post(`/slides/${selected.id}/revert`, { versionIndex: index });
+      const updated = res.data.slide as Slide;
+      updateSlideInState(updated);
+      setDiff(null);
+    } catch (err) {
+      setError('Revert failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadVersions = async () => {
+    if (!selected) return [] as any[];
+    const res = await api.get(`/slides/${selected.id}/versions`);
+    return res.data.versions || [];
+  };
+
+  return (
+    <div className="flex h-screen">
+      <div className="w-1/5 border-r overflow-y-auto">
+        {slides.map((s) => (
+          <div key={s.id} onClick={() => setSelected(s)} className={`p-2 cursor-pointer ${selected?.id === s.id ? 'bg-gray-200' : ''}`}>{s.title}</div>
+        ))}
+      </div>
+      <div className="w-3/5 p-4 overflow-auto">
+        <div className="border p-4 bg-white rounded min-h-[70vh]">
+          {diff ? (
+            <div>
+              {diff.map((p, i) => (
+                <span
+                  key={i}
+                  className={p.added ? 'bg-green-200' : p.removed ? 'bg-red-200 line-through' : ''}
+                >
+                  {p.value}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <div dangerouslySetInnerHTML={{ __html: selected?.currentHtml || '' }} />
+          )}
+        </div>
+      </div>
+      <div className="w-1/5 p-4 flex flex-col">
+        <div className="flex-1 overflow-auto mb-2">
+          {selected?.chatHistory.map((m, i) => (
+            <div key={i} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+              <div className="text-xs font-semibold">{m.role}</div>
+              <div className="whitespace-pre-wrap text-sm">{m.content}</div>
+            </div>
+          ))}
+        </div>
+        <textarea
+          className="w-full border rounded p-2 mb-2"
+          placeholder="Edit instruction"
+          value={instruction}
+          onChange={(e) => setInstruction(e.target.value)}
+        />
+        <button onClick={applyEdit} disabled={loading} className="bg-blue-600 text-white px-4 py-2 rounded w-full">
+          {loading ? 'Applying...' : 'Apply Edit'}
+        </button>
+        {error && <div className="text-red-500 mt-2 text-sm">{error}</div>}
+        <button
+          onClick={async () => {
+            const versions = await loadVersions();
+            if (versions.length) revertVersion(versions.length - 1);
+          }}
+          className="mt-2 text-sm underline"
+        >
+          Revert Last
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/sow-web/src/routes/AppRouter.tsx
+++ b/sow-web/src/routes/AppRouter.tsx
@@ -4,6 +4,7 @@ import PreviewPage from '../pages/PreviewPage';
 import BrandingPage from '../pages/BrandingPage';
 import RunMarkdownPage from '../pages/RunMarkdownPage';
 import GeneratedSowPage from '../pages/GeneratedSowPage';
+import SlideEditorPage from '../pages/SlideEditorPage';
 
 export default function AppRouter() {
   return (
@@ -15,6 +16,7 @@ export default function AppRouter() {
         <Route path="/branding" element={<BrandingPage />} />
         <Route path="/run/:runId" element={<RunMarkdownPage />} />
         <Route path="/generated" element={<GeneratedSowPage />} />
+        <Route path="/slides" element={<SlideEditorPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -27,3 +27,23 @@ export const generateSow = async (markdown: string) => {
   const response = await api.post('/generate-sow', { markdown });
   return response.data;
 };
+
+export const generateSlides = async (fullSow: string) => {
+  const { data } = await api.post('/slides/generate', { fullSow });
+  return data.slides;
+};
+
+export const editSlide = async (id: string, instruction: string) => {
+  const { data } = await api.post(`/slides/${id}/edit`, { instruction });
+  return data.slide;
+};
+
+export const getVersions = async (id: string) => {
+  const { data } = await api.get(`/slides/${id}/versions`);
+  return data.versions;
+};
+
+export const revertSlide = async (id: string, versionIndex: number) => {
+  const { data } = await api.post(`/slides/${id}/revert`, { versionIndex });
+  return data.slide;
+};

--- a/tests/diff.test.js
+++ b/tests/diff.test.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { diffHtml } = require('../utils/diff');
+
+(() => {
+  const diff = diffHtml('<p>hello world</p>', '<p>hello there</p>');
+  const added = diff.find(p => p.added);
+  const removed = diff.find(p => p.removed);
+  assert(added && added.value.includes('there'));
+  assert(removed && removed.value.includes('world'));
+  console.log('✅ diff util works');
+})();

--- a/utils/diff.js
+++ b/utils/diff.js
@@ -1,0 +1,29 @@
+function diffHtml(oldHtml, newHtml) {
+  const oldParts = oldHtml.split(/(\s+)/).filter(Boolean);
+  const newParts = newHtml.split(/(\s+)/).filter(Boolean);
+  const diff = [];
+  let i = 0,
+    j = 0;
+  while (i < oldParts.length && j < newParts.length) {
+    if (oldParts[i] === newParts[j]) {
+      diff.push({ value: newParts[j] });
+      i++;
+      j++;
+    } else {
+      diff.push({ value: newParts[j], added: true });
+      diff.push({ value: oldParts[i], removed: true });
+      i++;
+      j++;
+    }
+  }
+  while (j < newParts.length) {
+    diff.push({ value: newParts[j], added: true });
+    j++;
+  }
+  while (i < oldParts.length) {
+    diff.push({ value: oldParts[i], removed: true });
+    i++;
+  }
+  return diff;
+}
+module.exports = { diffHtml };


### PR DESCRIPTION
## Summary
- add SlideEditorPage component with chat editing UI
- add slide editing helpers in frontend API service
- route `/slides` to new SlideEditorPage
- simple diff utility and test

## Testing
- `npm test` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b4f1eff58832a9ad0bc64f0653a79