### PR TITLE
Clean slide modules and add persistence tests

### DIFF
--- a/tests/mockPool.js
+++ b/tests/mockPool.js
@@ -1,0 +1,85 @@
+class MockPool {
+  constructor() {
+    this.runs = [];
+    this.slides = [];
+    this.slideVersions = [];
+    this.editLogs = [];
+    this.nextRunId = 1;
+  }
+  async connect() { return this; }
+  release() {}
+  async query(text, params) {
+    if (/^BEGIN/.test(text) || /^COMMIT/.test(text) || /^ROLLBACK/.test(text)) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (/INSERT INTO sow_runs/i.test(text)) {
+      const id = this.nextRunId++;
+      this.runs.push({ id, user_id: params[0], input_markdown: params[1] });
+      return { rows: [{ id }], rowCount: 1 };
+    }
+    if (/INSERT INTO slides/i.test(text)) {
+      const [id, runId, title, md, html, source, ver] = params;
+      this.slides.push({
+        id,
+        run_id: runId,
+        title,
+        original_markdown: md,
+        current_html: html,
+        model_source: source,
+        version_number: ver,
+        created_at: new Date(),
+        updated_at: new Date(),
+      });
+      return { rowCount: 1 };
+    }
+    if (/INSERT INTO slide_versions/i.test(text)) {
+      const [slideId, html, source, instruction, ver] = params;
+      this.slideVersions.push({
+        slide_id: slideId,
+        html,
+        source,
+        instruction,
+        version_number: ver,
+        created_at: new Date(),
+      });
+      return { rowCount: 1 };
+    }
+    if (/INSERT INTO slide_edit_logs/i.test(text)) {
+      const [slideId, userId, action, instruction, fromVer, toVer] = params;
+      this.editLogs.push({ slide_id: slideId, user_id: userId, action, instruction, from_version: fromVer, to_version: toVer });
+      return { rowCount: 1 };
+    }
+    if (/SELECT version_number FROM slides WHERE id=\$1/i.test(text)) {
+      const slideId = params[0];
+      const slide = this.slides.find(s => s.id === slideId);
+      return { rowCount: slide ? 1 : 0, rows: slide ? [{ version_number: slide.version_number }] : [] };
+    }
+    if (/UPDATE slides SET current_html=/i.test(text)) {
+      const [html, source, versionNumber, slideId] = params;
+      const slide = this.slides.find(s => s.id === slideId);
+      if (!slide) return { rowCount: 0 };
+      slide.current_html = html;
+      slide.model_source = source;
+      slide.version_number = versionNumber;
+      slide.updated_at = new Date();
+      return { rowCount: 1 };
+    }
+    if (/SELECT \* FROM slides WHERE run_id=\$1/i.test(text)) {
+      const runId = params[0];
+      const rows = this.slides.filter(s => s.run_id === runId);
+      return { rows };
+    }
+    if (/SELECT \* FROM slides WHERE id=\$1/i.test(text)) {
+      const slideId = params[0];
+      const slide = this.slides.find(s => s.id === slideId);
+      return { rowCount: slide ? 1 : 0, rows: slide ? [slide] : [] };
+    }
+    if (/SELECT version_number, instruction, source, html, created_at FROM slide_versions WHERE slide_id=\$1/i.test(text)) {
+      const slideId = params[0];
+      const rows = this.slideVersions.filter(v => v.slide_id === slideId).sort((a,b)=>a.version_number-b.version_number);
+      return { rows, rowCount: rows.length };
+    }
+    throw new Error('Unhandled query: ' + text);
+  }
+}
+module.exports = new MockPool();

--- a/tests/slidePersistence.test.js
+++ b/tests/slidePersistence.test.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const mockPool = require('./mockPool');
+require.cache[require.resolve('../services/db')] = { exports: { pool: mockPool } };
+
+const {
+  createRunWithSlides,
+  persistSlideEdit,
+  getSlidesByRun,
+  getSlideWithHistory,
+} = require('../services/slidePersistence');
+
+function revertSlideToVersion(slide, versionIndex) {
+  if (versionIndex < 0 || versionIndex >= slide.versionHistory.length) {
+    throw new Error('Invalid version index');
+  }
+  const version = slide.versionHistory[versionIndex];
+  slide.versionHistory.push({
+    html: slide.currentHtml,
+    timestamp: Date.now(),
+    source: 'revert',
+    instruction: `Reverted to version ${versionIndex}`,
+  });
+  slide.currentHtml = version.html;
+  return slide;
+}
+
+(async () => {
+  const slides = [
+    {
+      id: 's1',
+      title: 'Slide 1',
+      originalMarkdown: 'one',
+      currentHtml: '<p>1</p>',
+      versionHistory: [{ html: '<p>1</p>', source: 'init', instruction: 'initial generation' }],
+      chatHistory: [],
+    },
+    {
+      id: 's2',
+      title: 'Slide 2',
+      originalMarkdown: 'two',
+      currentHtml: '<p>2</p>',
+      versionHistory: [{ html: '<p>2</p>', source: 'init', instruction: 'initial generation' }],
+      chatHistory: [],
+    },
+  ];
+
+  const runId = await createRunWithSlides('full md', slides, null);
+  assert.strictEqual(runId, 1);
+
+  let stored = await getSlidesByRun(runId);
+  assert.strictEqual(stored.length, 2);
+  assert.strictEqual(stored[0].versionNumber, 1);
+
+  await persistSlideEdit('s1', '<p>a1</p>', 'mock', 'edit1');
+  let slide = await getSlideWithHistory('s1');
+  assert.strictEqual(slide.currentHtml, '<p>a1</p>');
+  assert.strictEqual(slide.versionNumber, 2);
+  assert.strictEqual(slide.versionHistory.length, 2);
+
+  await persistSlideEdit('s1', '<p>a2</p>', 'mock', 'edit2');
+  slide = await getSlideWithHistory('s1');
+  assert.strictEqual(slide.versionNumber, 3);
+
+  // revert to version 0
+  const revertedObj = revertSlideToVersion(slide, 0);
+  await persistSlideEdit('s1', revertedObj.currentHtml, 'revert', 'revert to v1');
+  slide = await getSlideWithHistory('s1');
+  assert.strictEqual(slide.currentHtml, '<p>1</p>');
+  assert.strictEqual(slide.versionNumber, 4);
+  assert.strictEqual(slide.versionHistory.length, 4);
+
+  console.log('✅ slidePersistence operations work');
+})();


### PR DESCRIPTION
## Summary
- refactor `services/slidePersistence.js` with `getSlideWithHistory`
- update slide routes to use normalization and history helpers
- add mock database pool for tests
- add basic unit tests for slide persistence

## Testing
- `node tests/slidePersistence.test.js`
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b538ae154832ab0ee10e7dbfbed06