### PR TITLE
Fix slide persistence hygiene

### DIFF
--- a/routes/slides.js
+++ b/routes/slides.js
@@ -7,7 +7,6 @@ const {
   persistSlideEdit,
   getSlidesByRun,
   getSlideWithHistory,
-  normalizeSlideRow,
 } = require('../services/slidePersistence');
 const { pool } = require('../services/db');
 const { brandContext } = require('../config/brandContext');

--- a/services/slidePersistence.js
+++ b/services/slidePersistence.js
@@ -101,6 +101,9 @@ async function getSlideWithHistory(slideId) {
     createdAt: v.created_at,
   }));
 
+  // ensure chatHistory array exists for editing logic
+  slide.chatHistory = slide.chatHistory || [];
+
   return slide;
 }
 

--- a/tests/slidePersistence.test.js
+++ b/tests/slidePersistence.test.js
@@ -9,6 +9,9 @@ const {
   getSlideWithHistory,
 } = require('../services/slidePersistence');
 
+// Test-only helper mirroring slideEditor.revertSlideToVersion. Keeps the
+// persistence tests independent from editor logic.
+
 function revertSlideToVersion(slide, versionIndex) {
   if (versionIndex < 0 || versionIndex >= slide.versionHistory.length) {
     throw new Error('Invalid version index');


### PR DESCRIPTION
## Summary
- remove unused helper import from slides route
- hydrate `chatHistory` in `getSlideWithHistory`
- document revert helper in slidePersistence tests

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b565b21d4832a9434dc70b14f1524