### PR TITLE
Expose slide retrieval endpoint & PPTX export improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Slides are generated and edited via the `/slides` routes.
 
 * `POST /slides/generate` body `{ fullSow: "markdown" }` → returns an array of slide objects with `id` and `currentHtml`.
 * `POST /slides/:id/edit` body `{ instruction: "Add teal header" }` → updates the slide and returns it.
+* `GET /slides/:id` → returns a single slide with its version and chat history.
 * `GET /slides/:id/versions` → lists prior versions of the slide HTML.
 * `POST /slides/:id/revert` body `{ versionIndex: 0 }` → restores a previous version.
 
@@ -31,4 +32,4 @@ Each slide tracks `chatHistory`, `currentHtml`, and `versionHistory` as it is ed
 When `DATABASE_URL` is provided, generated slides are persisted with a run identifier. Additional endpoints become available:
 
 * `GET /slides/export/html/:runId` → downloads a consolidated HTML presentation for a run.
-* `GET /export/pptx/run/:runId` → generates a PPTX file from the stored slides.
+* `GET /export/pptx/run/:runId` → generates a PPTX file from the stored slides using their latest HTML.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/diff.test.js"
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/services/slideEditor.js
+++ b/services/slideEditor.js
@@ -54,6 +54,7 @@ async function applySlideEdit(slide, userInstruction) {
     instruction: userInstruction,
   });
   slide.currentHtml = sanitized;
+  slide.versionNumber = slide.versionHistory.length;
   slide.chatHistory.push({ role: 'user', content: userInstruction, timestamp: Date.now() });
   slide.chatHistory.push({ role: 'assistant', content: sanitized, timestamp: Date.now() });
   logAiUsage({ prompt: userInstruction, source, duration, outputLength: (updatedHtmlRaw || '').length });
@@ -72,6 +73,7 @@ function revertSlideToVersion(slide, versionIndex) {
     instruction: `Reverted to version ${versionIndex}`,
   });
   slide.currentHtml = version.html;
+  slide.versionNumber = slide.versionHistory.length;
   return slide;
 }
 

--- a/services/slideGenerator.js
+++ b/services/slideGenerator.js
@@ -80,6 +80,7 @@ async function generateSlidesFromMarkdown(fullMarkdown, brandContext) {
     const sanitized = sanitizeHtmlFragment(text);
     slide.versionHistory.push({ html: slide.currentHtml, timestamp: Date.now(), source });
     slide.currentHtml = sanitized;
+    slide.versionNumber = slide.versionHistory.length;
     logAiUsage({ prompt, source, duration, outputLength: (text || '').length });
     slide.chatHistory.push({ role: 'assistant', content: sanitized });
   }

--- a/tests/slidesIntegration.test.js
+++ b/tests/slidesIntegration.test.js
@@ -1,0 +1,63 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 't';
+process.env.GEMINI_API_KEY = 'g';
+
+const mockPool = require('./mockPool');
+require.cache[require.resolve('../services/db')] = { exports: { pool: mockPool } };
+
+const aiMock = {
+  generateWithFallback: async () => ({ source: 'mock', text: '<p>orig</p>' }),
+  editWithFallback: async () => ({ source: 'mock', text: '<p>edited</p>' })
+};
+require.cache[require.resolve('../services/aiProvider')] = { exports: aiMock };
+
+const app = require('../server');
+const getHandler = p => app._router.stack.find(r => r.route && r.route.path === p).route.stack[0].handle;
+
+(async () => {
+  const gen = getHandler('/slides/generate');
+  const edit = getHandler('/slides/:slideId/edit');
+  const versions = getHandler('/slides/:slideId/versions');
+  const revert = getHandler('/slides/:slideId/revert');
+  const fetchOne = getHandler('/slides/:slideId');
+  const exportHtml = getHandler('/slides/export/html/:runId');
+  const exportPptx = getHandler('/export/pptx/run/:runId');
+
+  // generate slides
+  let genData;
+  await gen({ body: { fullSow: '## Slide 1\nA' } }, { json: d => { genData = d; }, status() { return this; } });
+  const runId = genData.runId;
+  const slideId = genData.slides[0].id;
+  assert.strictEqual(genData.slides[0].versionNumber, 1);
+
+  // edit
+  await edit({ params: { slideId }, body: { instruction: 'change' } }, { json() {}, status() { return this; } });
+
+  // versions
+  let ver;
+  await versions({ params: { slideId } }, { json: d => { ver = d; }, status() { return this; } });
+  assert.strictEqual(ver.versions.length, 2);
+
+  // revert
+  await revert({ params: { slideId }, body: { versionIndex: 0 } }, { json() {}, status() { return this; } });
+
+  // fetch single
+  let single;
+  await fetchOne({ params: { slideId } }, { json: d => { single = d; }, status() { return this; } });
+  assert.strictEqual(single.slide.versionNumber, 3);
+  assert.strictEqual(single.slide.versionHistory.length, 3);
+
+  // export html
+  let html = '';
+  await exportHtml({ params: { runId } }, { setHeader() {}, send: h => { html = h; }, status() { return this; }, json() {} });
+  assert(html.includes('<p>orig</p>'));
+
+  // export pptx
+  let pptBuf;
+  await exportPptx({ params: { runId } }, { setHeader() {}, send: b => { pptBuf = b; }, status() { return this; }, json() {} });
+  assert.ok(Buffer.isBuffer(pptBuf));
+  assert.ok(pptBuf.length > 0);
+  assert.ok(pptBuf.toString().includes('Slide 1'));
+
+  console.log('✅ slides integration flow works');
+})();


### PR DESCRIPTION
## Summary
- expose `GET /slides/:slideId` for single slide retrieval with history
- track `versionNumber` in slide generator and editor
- generate PPTX exports from `currentHtml`
- document the new endpoint and PPTX behaviour
- integration test for slide lifecycle and exports

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b585d034c832ab11481cd190dc7da