### PR TITLE
Fix pdf template style

### DIFF
--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="utf-8" />
     <title>Scope of Work</title>
-    <style>{{{css}}}</style>
+    <style>
+        {{{css}}}
+    </style>
 </head>
 <body>
 {{{html}}}


### PR DESCRIPTION
## Summary
- fix syntax error in `templates/pdf.html` by expanding the `<style>` block

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b72c38fe4832a9b7aa00958200bac