### PR TITLE
Update slide lock semantics and add migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js"
+    "migrate": "node scripts/migrate.js",
+    "test": "node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js && node tests/lockSlideRoute.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const { pool } = require('../services/db');
+
+async function runMigrations() {
+  if (!pool) {
+    console.log('DATABASE_URL not configured, skipping migrations');
+    return;
+  }
+  const dir = path.join(__dirname, '../migrations');
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(dir, file), 'utf8');
+    await pool.query(sql);
+  }
+  console.log('Migrations applied');
+}
+
+if (require.main === module) {
+  runMigrations().then(() => process.exit(0)).catch(err => { console.error(err); process.exit(1); });
+}
+
+module.exports = runMigrations;

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ const { generateWithFallback } = require('./services/aiProvider');
 const { logAiUsage } = require('./utils/logging');
 const slideRoutes = require('./routes/slides');
 const { pool } = require('./services/db');
+const runMigrations = require('./scripts/migrate');
 
 // 2. Initialize Express App & Gemini AI
 const app = express();
@@ -40,6 +41,10 @@ if (!geminiApiKey) {
 }
 const genAI = new GoogleGenerativeAI(geminiApiKey);
 const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+
+if (pool && process.env.RUN_MIGRATIONS === 'true') {
+  runMigrations().catch(err => console.error('Migration error:', err));
+}
 
 
 // --- Google Sheets Integration ---

--- a/tests/lockSlideRoute.test.js
+++ b/tests/lockSlideRoute.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+process.env.TOGETHER_API_KEY = 't';
+process.env.GEMINI_API_KEY = 'g';
+
+const mockPool = require('./mockPool');
+require.cache[require.resolve('../services/db')] = { exports: { pool: mockPool } };
+
+const aiMock = {
+  generateWithFallback: async () => ({ source: 'mock', text: '<p>orig</p>' }),
+  editWithFallback: async () => ({ source: 'mock', text: '<p>edited</p>' })
+};
+require.cache[require.resolve('../services/aiProvider')] = { exports: aiMock };
+
+const app = require('../server');
+const getHandler = p => app._router.stack.find(r => r.route && r.route.path === p).route.stack[0].handle;
+
+(async () => {
+  const gen = getHandler('/slides/generate');
+  const edit = getHandler('/slides/:slideId/edit');
+  const revert = getHandler('/slides/:slideId/revert');
+  const lock = getHandler('/slides/:slideId/lock');
+  const unlock = getHandler('/slides/:slideId/unlock');
+  const fetchOne = getHandler('/slides/:slideId');
+
+  let data;
+  await gen({ body: { fullSow: '## Slide 1\nA' } }, { json: d => { data = d; }, status(){ return this; } });
+  const slideId = data.slides[0].id;
+
+  await lock({ params: { slideId } }, { json() {}, status(){ return this; } });
+  let slide;
+  await fetchOne({ params:{ slideId } }, { json: d => { slide = d.slide; }, status(){ return this; } });
+  assert.strictEqual(slide.isLocked, true);
+  assert.ok(slide.finalizedAt instanceof Date);
+
+  const conflict = { statusCode:null, json(){}, status(c){ this.statusCode=c; return this; } };
+  await edit({ params:{ slideId }, body:{ instruction:'x' } }, conflict);
+  assert.strictEqual(conflict.statusCode, 409);
+  await revert({ params:{ slideId }, body:{ versionIndex:0 } }, conflict);
+  assert.strictEqual(conflict.statusCode, 409);
+
+  await unlock({ params:{ slideId } }, { json() {}, status(){ return this; } });
+  await revert({ params:{ slideId }, body:{ versionIndex:0 } }, { json(){}, status(){ return this; } });
+  console.log('✅ lock/unlock persistence and guards work');
+})();

--- a/tests/slidesIntegration.test.js
+++ b/tests/slidesIntegration.test.js
@@ -70,11 +70,16 @@ const getHandler = p => app._router.stack.find(r => r.route && r.route.path === 
   const conflict = { statusCode: null, data: null, status(c){ this.statusCode = c; return this; }, json(d){ this.data = d; } };
   await edit({ params: { slideId }, body: { instruction: 'x' } }, conflict);
   assert.strictEqual(conflict.statusCode, 409);
+  await revert({ params:{ slideId }, body:{ versionIndex:0 } }, conflict);
+  assert.strictEqual(conflict.statusCode, 409);
 
   // unlock slide
   let unlockRes;
   await unlock({ params: { slideId } }, { json: d => { unlockRes = d; }, status(){ return this; } });
   assert.strictEqual(unlockRes.slide.isLocked, false);
+
+  // revert now that it's unlocked
+  await revert({ params:{ slideId }, body:{ versionIndex:0 } }, { json(){}, status(){ return this; } });
 
   // edit should succeed now
   await edit({ params: { slideId }, body: { instruction: 'y' } }, { json() {}, status(){ return this; } });


### PR DESCRIPTION
## Summary
- block revert on locked slides
- return full slide after lock/unlock
- add startup option to run migrations and standalone script
- test lock/unlock flow
- update integration test

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b72e28a48832ab222249bff16a3a1