### PR TITLE
Implement debounced slide editor

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "author": "",
   "license": "ISC",
@@ -21,6 +21,19 @@
     "pdf-parse": "^1.1.1",
     "cropperjs": "^1.6.1",
     "micromodal": "^0.4.10",
-    "@toast-ui/editor": "^3.2.2"
+    "@toast-ui/editor": "^3.2.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "lodash.debounce": "^4.0.8"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0",
+    "@types/jest": "^29.2.0"
   }
 }

--- a/src/components/SlideEditorPage.tsx
+++ b/src/components/SlideEditorPage.tsx
@@ -1,0 +1,115 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import debounce from 'lodash.debounce';
+
+interface Slide {
+  id: string;
+  currentHtml: string;
+  versionNumber?: number;
+}
+
+interface Props {
+  slide: Slide;
+  onUpdate: (updated: Partial<Slide>) => void;
+}
+
+export default function SlideEditorPage({ slide, onUpdate }: Props) {
+  const [instruction, setInstruction] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const latestInstructionRef = useRef(instruction);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    latestInstructionRef.current = instruction;
+  }, [instruction]);
+
+  const sendEdit = useCallback(
+    async (instr: string) => {
+      if (!instr.trim()) return;
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setPending(true);
+      setError(null);
+
+      try {
+        const resp = await fetch(`/slides/${slide.id}/edit`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instruction: instr }),
+          signal: controller.signal,
+        });
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${resp.status}`);
+        }
+        const data = await resp.json();
+        onUpdate(data.slide);
+      } catch (e: any) {
+        if (e.name === 'AbortError') {
+          return;
+        }
+        setError(e.message || 'Edit failed');
+      } finally {
+        setPending(false);
+      }
+    },
+    [slide.id, onUpdate]
+  );
+
+  const debouncedSend = useRef(
+    debounce((instr: string) => {
+      void sendEdit(instr);
+    }, 500)
+  ).current;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInstruction(e.target.value);
+    debouncedSend(e.target.value);
+  };
+
+  const handleApply = () => {
+    debouncedSend.cancel();
+    void sendEdit(instruction);
+  };
+
+  useEffect(() => {
+    return () => {
+      debouncedSend.cancel();
+      if (abortControllerRef.current) abortControllerRef.current.abort();
+    };
+  }, [debouncedSend]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Edit Instruction</label>
+        <textarea
+          value={instruction}
+          onChange={handleChange}
+          disabled={pending}
+          className="w-full border rounded p-2"
+          rows={3}
+          placeholder="e.g., Make the header teal and increase font size"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleApply}
+          disabled={pending || !instruction.trim()}
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+        >
+          {pending ? 'Applying...' : 'Apply'}
+        </button>
+        {pending && <span className="text-sm text-gray-600">Edit in progress...</span>}
+      </div>
+
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+    </div>
+  );
+}
+

--- a/tests/SlideEditorPage.test.tsx
+++ b/tests/SlideEditorPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import SlideEditorPage from '../src/components/SlideEditorPage';
+
+jest.useFakeTimers();
+
+const mockSlide = { id: 's1', currentHtml: '<p>orig</p>' };
+const mockOnUpdate = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (global as any).fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ slide: { id: 's1', currentHtml: '<p>edited</p>' } })
+    })
+  );
+});
+
+test('debounces rapid input into a single API call and disables button while pending', async () => {
+  render(<SlideEditorPage slide={mockSlide as any} onUpdate={mockOnUpdate} />);
+
+  const textarea = screen.getByRole('textbox');
+  const button = screen.getByRole('button', { name: /apply/i });
+
+  fireEvent.change(textarea, { target: { value: 'first' } });
+  fireEvent.change(textarea, { target: { value: 'second' } });
+  fireEvent.change(textarea, { target: { value: 'final instruction' } });
+
+  jest.advanceTimersByTime(500);
+
+  await waitFor(() => expect(button).toBeDisabled());
+  expect((global as any).fetch).toHaveBeenCalledTimes(1);
+
+  await waitFor(() => expect(mockOnUpdate).toHaveBeenCalledWith({ id: 's1', currentHtml: '<p>edited</p>' }));
+
+  expect(button).not.toBeDisabled();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- add new `SlideEditorPage` React component implementing debouncing and request cancellation
- scaffold Jest setup and unit test for the editor
- add React and testing dependencies with config files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8ede7244832a98374f1fc9ae0256