### PR TITLE
Enable slide generation from SOW and add browser preview

### DIFF
--- a/sow-web/src/pages/GeneratedSowPage.tsx
+++ b/sow-web/src/pages/GeneratedSowPage.tsx
@@ -1,11 +1,24 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { generateSlides } from '../services/api';
 
 export default function GeneratedSowPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const initial = (location.state as any)?.markdown || '';
   const [markdown, setMarkdown] = useState(initial);
+  const [generating, setGenerating] = useState(false);
+  const handleGenerateSlides = async () => {
+    setGenerating(true);
+    try {
+      const slides = await generateSlides(markdown);
+      navigate('/slides', { state: { slides, markdown } });
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setGenerating(false);
+    }
+  };
 
   return (
     <div className="p-6 max-w-3xl mx-auto">
@@ -18,6 +31,13 @@ export default function GeneratedSowPage() {
         value={markdown}
         onChange={(e) => setMarkdown(e.target.value)}
       />
+      <button
+        className="px-4 py-2 bg-green-600 text-white rounded"
+        onClick={handleGenerateSlides}
+        disabled={generating}
+      >
+        {generating ? 'Generating...' : 'Generate Slides'}
+      </button>
     </div>
   );
 }

--- a/sow-web/src/pages/PreviewPage.tsx
+++ b/sow-web/src/pages/PreviewPage.tsx
@@ -1,7 +1,48 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+
 export default function PreviewPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const slides = (location.state as any)?.slides || [];
+  const [index, setIndex] = useState(0);
+
+  if (!slides.length) {
+    return (
+      <div className="p-6 text-center">
+        <p className="mb-4">No slides to preview.</p>
+        <button className="underline" onClick={() => navigate(-1)}>
+          Back
+        </button>
+      </div>
+    );
+  }
+
+  const prev = () => setIndex((i) => Math.max(i - 1, 0));
+  const next = () => setIndex((i) => Math.min(i + 1, slides.length - 1));
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-6">
-      <h1 className="text-2xl font-bold mb-4">Preview Page</h1>
+      <div className="flex-grow flex items-center justify-center w-full">
+        <div
+          className="bg-white p-6 rounded shadow max-w-3xl w-full"
+          dangerouslySetInnerHTML={{ __html: slides[index].currentHtml }}
+        />
+      </div>
+      <div className="mt-4 flex items-center space-x-4">
+        <button onClick={prev} disabled={index === 0} className="px-4 py-2 bg-gray-200 rounded">
+          Prev
+        </button>
+        <span>
+          {index + 1} / {slides.length}
+        </span>
+        <button onClick={next} disabled={index === slides.length - 1} className="px-4 py-2 bg-gray-200 rounded">
+          Next
+        </button>
+      </div>
+      <button onClick={() => navigate(-1)} className="mt-4 underline text-blue-600">
+        Back to Editor
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow generating slides from actual SOW markdown
- wire GeneratedSowPage to create slides and open the editor
- update SlideEditorPage to consume passed markdown/slides and add preview button
- implement PreviewPage to show a slideshow

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688b922c4c94832aad032297e08e7530