### PR TITLE
Increase body parser limit to avoid 413 errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -983,8 +983,8 @@ async function sowOrchestrator(brdText) {
 }
 // --- Configure Middleware & Routes ---
 app.use(cors());
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 app.use(fileUpload());
 app.use('/images/headshots', express.static(tempDir));
 


### PR DESCRIPTION
## Summary
- allow larger request payloads by increasing body-parser limits

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9b0b06d0832a91411d9c2cf6a5f6