### PR TITLE
Increase express body size limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -983,8 +983,11 @@ async function sowOrchestrator(brdText) {
 }
 // --- Configure Middleware & Routes ---
 app.use(cors());
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+// Increase body size limits to handle large SOW payloads and slide requests
+// The previous 10mb limit was too small for some generate operations, causing
+// `PayloadTooLargeError` (HTTP 413) errors when large documents were sent.
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 app.use(fileUpload());
 app.use('/images/headshots', express.static(tempDir));
 


### PR DESCRIPTION
## Summary
- avoid `PayloadTooLargeError` when sending large slide generation requests
- bump `express.json` and `express.urlencoded` limit to 50mb

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688bae1c0ce8832a92c42a6c64364593