### PR TITLE
Add debug option for AI prompt logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ TOGETHER_API_BASE=https://api.together.ai
 # Cache settings
 CACHE_TTL_MS=3600000
 ADMIN_TOKEN=changeme
+# Enable to print full AI prompts in logs
+DEBUG_PROMPTS=true
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.

--- a/utils/logging.js
+++ b/utils/logging.js
@@ -4,8 +4,15 @@ function hash(text) {
   return crypto.createHash('sha256').update(text).digest('hex');
 }
 
+const SHOW_FULL_PROMPTS = process.env.DEBUG_PROMPTS === 'true';
+
 function logAiUsage({ prompt, source, duration, outputLength }) {
-  console.info(`[AI] PromptHash=${hash(prompt)} Source=${source} DurationMs=${duration} OutputLength=${outputLength}`);
+  if (SHOW_FULL_PROMPTS) {
+    console.info(`[AI_PROMPT] ${prompt}`);
+  }
+  const promptField = SHOW_FULL_PROMPTS ? `Prompt` : `PromptHash`;
+  const promptValue = SHOW_FULL_PROMPTS ? prompt.replace(/\s+/g, ' ') : hash(prompt);
+  console.info(`[AI] ${promptField}=${promptValue} Source=${source} DurationMs=${duration} OutputLength=${outputLength}`);
 }
 
 let cacheHits = 0;


### PR DESCRIPTION
## Summary
- allow verbose prompt logging with a `DEBUG_PROMPTS` env var
- document the new setting in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c71a11b34832abe173c6d0b94a5d0