### PR TITLE
Add Lambda handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ When `DATABASE_URL` is provided, generated slides are persisted with a run ident
 
 * `GET /slides/export/html/:runId` → downloads a consolidated HTML presentation for a run.
 * `GET /export/pptx/run/:runId` → generates a PPTX file from the stored slides using their latest HTML.
+## Lambda Deployment
+
+To run the Express app on AWS Lambda with API Gateway, install `serverless-http` and create `lambda.js`:
+
+```js
+const serverless = require('serverless-http');
+const app = require('./server');
+
+module.exports.handler = serverless(app);
+```
+
+Deploy `lambda.js` as a Lambda function and attach an API Gateway trigger.
+
+

--- a/README.md
+++ b/README.md
@@ -52,4 +52,23 @@ module.exports.handler = serverless(app);
 
 Deploy `lambda.js` as a Lambda function and attach an API Gateway trigger.
 
+## AWS Amplify Deployment
+
+1. **Connect Repository** - In the AWS Amplify console create a new app and
+   connect this repository. Amplify will use `amplify.yml` to build the
+   frontend located in `sow-web`.
+2. **Package the Backend** - Run `npm run package-lambda` to create
+   `lambda.zip` containing the Express application and its dependencies.
+   Upload this archive as a Lambda function and set the handler to
+   `lambda.handler`.
+3. **Create API Gateway** - Add an HTTP API Gateway trigger for the Lambda
+   function and note the invoke URL. Configure environment variables in the
+   Lambda function to match `.env`.
+4. **Point the Frontend** - In Amplify add an environment variable
+   `VITE_API_BASE_URL` set to the API Gateway URL so the React app can reach the
+   backend.
+
+With these steps the SOW web frontend will be served by Amplify and all backend
+requests will be routed through the Lambda/API Gateway endpoint.
+
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ TOGETHER_API_BASE=https://api.together.ai
 # Cache settings
 CACHE_TTL_MS=3600000
 ADMIN_TOKEN=changeme
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.

--- a/lambda.js
+++ b/lambda.js
@@ -1,0 +1,4 @@
+const serverless = require('serverless-http');
+const app = require('./server');
+
+module.exports.handler = serverless(app);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "node server.js",
     "migrate": "node scripts/migrate.js",
     "test": "TOGETHER_API_KEY=t GEMINI_API_KEY=g node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/chatHistorySummarization.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js && node tests/lockSlideRoute.test.js && node tests/slideMutationQueue.test.js && node tests/cache.test.js"
+    ,
+    "package-lambda": "bash scripts/package-lambda.sh"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "mammoth": "^1.7.2",
     "md-to-pdf": "^5.1.0",
     "pdf-parse": "^1.1.1",
-    "sanitize-html": "^2.12.1",
+    "pg": "^8.11.3",
     "pptxgenjs": "^3.9.0",
-    "pg": "^8.11.3"
+    "sanitize-html": "^2.12.1",
+    "serverless-http": "^3.3.0"
   }
 }
-

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install production dependencies
+npm ci --omit=dev
+
+ZIPFILE="lambda.zip"
+rm -f "$ZIPFILE"
+
+# Archive backend files and dependencies
+zip -r "$ZIPFILE" \
+  lambda.js server.js package.json package-lock.json \
+  config routes services utils templates migrations brandingAssets \
+  node_modules
+
+echo "Created $ZIPFILE"

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8000';
+// Read the API base URL from the environment so deployments can
+// target different backends without modifying the source.
+const API_BASE_URL =
+  (import.meta as any).env.VITE_API_BASE_URL || 'http://localhost:8000';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- add serverless-http dependency
- create lambda handler for express app
- document Lambda deployment instructions

## Testing
- `npm test` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_688cbdbd628c832aadfb3e71090cf1a8