### PR TITLE
Fix API base URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ TOGETHER_API_BASE=https://api.together.ai
 # Cache settings
 CACHE_TTL_MS=3600000
 ADMIN_TOKEN=changeme
+VITE_API_BASE_URL=http://localhost:8000
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8000';
+// Read the API base URL from the environment so deployments can
+// target different backends without modifying the source.
+const API_BASE_URL =
+  (import.meta as any).env.VITE_API_BASE_URL || 'http://localhost:8000';
 
 export const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- allow configuring API base URL at runtime
- document new `VITE_API_BASE_URL` setting

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688cc47ab1b8832a83268bfb7e7e2ba7