### PR TITLE
Add AWS Amplify deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,23 @@ module.exports.handler = serverless(app);
 
 Deploy `lambda.js` as a Lambda function and attach an API Gateway trigger.
 
+## AWS Amplify Deployment
+
+1. **Connect Repository** - In the AWS Amplify console create a new app and
+   connect this repository. Amplify will use `amplify.yml` to build the
+   frontend located in `sow-web`.
+2. **Package the Backend** - Run `npm run package-lambda` to create
+   `lambda.zip` containing the Express application and its dependencies.
+   Upload this archive as a Lambda function and set the handler to
+   `lambda.handler`.
+3. **Create API Gateway** - Add an HTTP API Gateway trigger for the Lambda
+   function and note the invoke URL. Configure environment variables in the
+   Lambda function to match `.env`.
+4. **Point the Frontend** - In Amplify add an environment variable
+   `VITE_API_BASE_URL` set to the API Gateway URL so the React app can reach the
+   backend.
+
+With these steps the SOW web frontend will be served by Amplify and all backend
+requests will be routed through the Lambda/API Gateway endpoint.
+
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "node server.js",
     "migrate": "node scripts/migrate.js",
     "test": "TOGETHER_API_KEY=t GEMINI_API_KEY=g node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/chatHistorySummarization.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js && node tests/lockSlideRoute.test.js && node tests/slideMutationQueue.test.js && node tests/cache.test.js"
+    ,
+    "package-lambda": "bash scripts/package-lambda.sh"
   },
   "author": "",
   "license": "ISC",

--- a/scripts/package-lambda.sh
+++ b/scripts/package-lambda.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install production dependencies
+npm ci --omit=dev
+
+ZIPFILE="lambda.zip"
+rm -f "$ZIPFILE"
+
+# Archive backend files and dependencies
+zip -r "$ZIPFILE" \
+  lambda.js server.js package.json package-lock.json \
+  config routes services utils templates migrations brandingAssets \
+  node_modules
+
+echo "Created $ZIPFILE"


### PR DESCRIPTION
## Summary
- document how to deploy backend/front-end via AWS Amplify
- provide script to package backend for Lambda
- add npm script to run the packaging step

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688ccb082448832a8b11b5e6e5c11462