### PR TITLE
feat: wire frontend to api gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Used to convert BRD into client ready SOW
 
 ## Environment Variables
 
-Create a `.env` file with the following entries:
+Create a `.env` file with the following entries for the backend:
 
 ```
 GEMINI_API_KEY=<your gemini key>
@@ -16,11 +16,29 @@ TOGETHER_API_BASE=https://api.together.ai
 # Cache settings
 CACHE_TTL_MS=3600000
 ADMIN_TOKEN=changeme
+# CORS configuration
+CORS_ORIGIN=https://your-frontend-domain.example.com
 ```
 
 The `PS_API_KEY` is required for the `/ps/tasks/:runId` endpoint which lists tasks for a workflow run.
 
-An admin endpoint `POST /admin/cache/clear` clears the in-memory slide cache and resets metrics. Send the `x-admin-token` header matching `ADMIN_TOKEN`.
+### Frontend
+
+The web frontend reads its backend URL from `VITE_API_BASE_URL`. Set this
+environment variable in the Amplify build or your local `.env` file to point to
+the deployed API Gateway URL. Two example stages are:
+
+```
+Staging:   https://wiztvffuyg.execute-api.us-east-1.amazonaws.com/staging
+Production: https://wiztvffuyg.execute-api.us-east-1.amazonaws.com/production
+```
+
+An optional `VITE_ADMIN_TOKEN` can be provided to enable admin UI features. It
+is sent as the `x-admin-token` header when calling admin routes such as
+`POST /admin/cache/clear`.
+
+An admin endpoint `POST /admin/cache/clear` clears the in-memory slide cache and
+resets metrics. Send the `x-admin-token` header matching `ADMIN_TOKEN`.
 
 ## Slide Editing API
 
@@ -69,5 +87,24 @@ Deploy `lambda.js` as a Lambda function and attach an API Gateway trigger.
 
 With these steps the SOW web frontend will be served by Amplify and all backend
 requests will be routed through the Lambda/API Gateway endpoint.
+
+## Manual Testing
+
+To verify the API stages directly:
+
+```
+curl -i "https://wiztvffuyg.execute-api.us-east-1.amazonaws.com/staging/ps/runs?workflowId=<some-id>"
+curl -i "https://wiztvffuyg.execute-api.us-east-1.amazonaws.com/production/ps/runs?workflowId=<some-id>"
+```
+
+Admin routes require the token header:
+
+```
+curl -i -H "x-admin-token: <token>" "https://wiztvffuyg.execute-api.us-east-1.amazonaws.com/staging/admin/cache/clear"
+```
+
+When the frontend is deployed, open the browser console to confirm a log similar
+to `Resolved API base URL: https://.../staging`. Network requests such as
+`/ps/runs` should hit the same base URL and return data without CORS errors.
 
 

--- a/server.js
+++ b/server.js
@@ -1004,7 +1004,21 @@ async function sowOrchestrator(brdText, brandContext) {
     return finalMarkdown;
 }
 // --- Configure Middleware & Routes ---
-app.use(cors());
+// Configure CORS to allow the frontend apps to access the API through API
+// Gateway. Allowed origins can be provided as a comma-separated list via the
+// CORS_ORIGIN environment variable, otherwise all origins are permitted (useful
+// for local testing).
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',')
+  : '*';
+app.use(
+  cors({
+    origin: allowedOrigins,
+    methods: ['GET', 'POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'x-admin-token'],
+    maxAge: 600,
+  })
+);
 app.use(express.json({ limit: '100mb' }));
 app.use(express.urlencoded({ extended: true, limit: '100mb' }));
 app.use(fileUpload());

--- a/sow-web/src/services/api.ts
+++ b/sow-web/src/services/api.ts
@@ -1,9 +1,17 @@
 import axios from 'axios';
 
-// Read the API base URL from the environment so deployments can
-// target different backends without modifying the source.
-const API_BASE_URL =
-  (import.meta as any).env.VITE_API_BASE_URL || 'http://localhost:8000';
+// Resolve the API base URL in a fail-fast manner so deployments always
+// point to the intended backend. Local development may fall back to the
+// Node server running on port 8000.
+const API_BASE_URL = (() => {
+  const envUrl = (import.meta as any).env.VITE_API_BASE_URL;
+  if (envUrl) return envUrl;
+  if (import.meta.env.DEV) return 'http://localhost:8000';
+  console.error('🚨 Missing VITE_API_BASE_URL in production build.');
+  throw new Error('VITE_API_BASE_URL is required in non-dev environments');
+})();
+
+console.log('Resolved API base URL:', API_BASE_URL);
 
 export const api = axios.create({
   baseURL: API_BASE_URL,
@@ -49,4 +57,24 @@ export const getVersions = async (id: string) => {
 export const revertSlide = async (id: string, versionIndex: number) => {
   const { data } = await api.post(`/slides/${id}/revert`, { versionIndex });
   return data.slide;
+};
+
+// --- Admin Endpoints ---
+// `clearAdminCache` demonstrates how to call admin routes that require the
+// `x-admin-token` header. The token can be provided explicitly or via a
+// `VITE_ADMIN_TOKEN` environment variable exposed to the frontend.
+export const clearAdminCache = async (token?: string) => {
+  const adminToken = token || (import.meta as any).env.VITE_ADMIN_TOKEN;
+  if (!adminToken) {
+    throw new Error('Admin token required for admin requests');
+  }
+  await api.post(
+    '/admin/cache/clear',
+    {},
+    {
+      headers: {
+        'x-admin-token': adminToken,
+      },
+    }
+  );
 };


### PR DESCRIPTION
## Summary
- fail-fast API base URL resolution with console logging and admin endpoint helpers
- tighten Express CORS with configurable origins and admin header support
- document required env vars, API Gateway URLs, and manual test commands

## Testing
- `npm test`
- `VITE_API_BASE_URL=http://localhost:8000 npm --prefix sow-web run build`


------
https://chatgpt.com/codex/tasks/task_e_6890820ce504832aa59a9ea9fd8439ac