### PR TITLE
Log Plan Service API errors in /ps/runs route

### DIFF
--- a/server.js
+++ b/server.js
@@ -1150,7 +1150,14 @@ app.get('/ps/runs', async (req, res) => {
   const url = `${PS_BASE_URL}/workflow-runs?workflowId=${encodeURIComponent(workflowId)}`;
   try {
     const psRes = await fetch(url, { headers: { 'X-API-Key': PS_API_KEY } });
-    if (!psRes.ok) return res.status(psRes.status).json({ error: psRes.statusText });
+    if (!psRes.ok) {
+      const body = await psRes.text();
+      console.error('❌ PS API error listing workflow runs:', psRes.status, body);
+      return res.status(psRes.status).json({
+        error: 'Plan Service API request failed',
+        details: body
+      });
+    }
     const { workflowRuns } = await psRes.json();
     return res.json(workflowRuns);
   } catch (err) {


### PR DESCRIPTION
## Summary
- improve /ps/runs error handling by logging response status and body
- return a descriptive message on Plan Service API failures so clients can distinguish API errors from server errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68909b374c3c832aae3adbb4d3242f48