### PR TITLE
Include migrate script in lambda deployment package

### DIFF
--- a/scripts/package-lambda.js
+++ b/scripts/package-lambda.js
@@ -15,6 +15,7 @@ const files = [
   'templates',
   'migrations',
   'brandingAssets',
+  'scripts/migrate.js',
   'node_modules'
 ];
 


### PR DESCRIPTION
## Summary
- ensure `scripts/migrate.js` is packaged with lambda bundle

## Testing
- `npm test`
- `npm run package-lambda`
- `unzip -l lambda.zip | grep "scripts/migrate.js"`


------
https://chatgpt.com/codex/tasks/task_e_6890b4a39678832a9777a19e200a6389