### PR TITLE
chore(deploy): configure lambda handler to use lambda.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "TOGETHER_API_KEY=t GEMINI_API_KEY=g node tests/dataAggregator.test.js && node tests/brandContext.test.js && node tests/psTasksRoute.test.js && node tests/psSingleTaskRoute.test.js && node tests/psTasksPagination.test.js && node tests/psCreateRunRoute.test.js && node tests/psListRunsRoute.test.js && node tests/togetherClient.test.js && node tests/togetherClientMalformed.test.js && node tests/aiProvider.test.js && node tests/aiProviderFailure.test.js && node tests/slideGenerator.test.js && node tests/slideEditor.test.js && node tests/chatHistorySummarization.test.js && node tests/diff.test.js && node tests/slidesIntegration.test.js && node tests/lockSlideRoute.test.js && node tests/slideMutationQueue.test.js && node tests/cache.test.js",
     "prepare-lambda": "npm ci --production",
     "package-lambda": "node ./scripts/package-lambda.js",
-    "deploy": "npm run package-lambda && aws lambda update-function-code --function-name sow-backend --zip-file fileb://lambda.zip --region us-east-1"
+    "deploy": "npm run package-lambda && aws lambda update-function-code --function-name sow-backend --zip-file fileb://lambda.zip --region us-east-1 && aws lambda update-function-configuration --function-name sow-backend --handler lambda.handler --region us-east-1"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- configure the deploy script to update Lambda's handler to `lambda.handler`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890ce628da8832a85cc5b3460280593