### PR TITLE
feat: handle bom in google credentials

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,14 +47,17 @@ async function getPricingSheetData(retries = 3) {
     const rawCredentials = process.env.GOOGLE_CREDENTIALS;
     let authOptions;
     if (rawCredentials) {
+        const cleanedCreds = rawCredentials
+            .trim()
+            .replace(new RegExp('^\\uFEFF'), ''); // remove BOM if present
         let creds;
         try {
             // First attempt to parse as plain JSON with escaped newlines
-            creds = JSON.parse(rawCredentials.replace(/\\n/g, '\n'));
+            creds = JSON.parse(cleanedCreds.replace(/\\n/g, '\n'));
         } catch (e) {
             try {
                 // If direct parse fails, attempt base64 decoding then parse
-                const decoded = Buffer.from(rawCredentials, 'base64').toString('utf8');
+                const decoded = Buffer.from(cleanedCreds, 'base64').toString('utf8');
                 creds = JSON.parse(decoded.replace(/\\n/g, '\n'));
             } catch (err) {
                 console.error('Failed to parse GOOGLE_CREDENTIALS JSON:', err.message);


### PR DESCRIPTION
## Summary
- sanitize GOOGLE_CREDENTIALS by trimming and stripping BOMs
- use sanitized credentials for JSON and base64 parsing when accessing Google Sheets

## Testing
- `npm test`
- `node -e "function parseCreds(input){const cleanedCreds=input.trim().replace(new RegExp('^\\uFEFF'),'');let creds;try{creds=JSON.parse(cleanedCreds.replace(/\\n/g,'\n'));}catch(e){const decoded=Buffer.from(cleanedCreds,'base64').toString('utf8');creds=JSON.parse(decoded.replace(/\\n/g,'\n'));}return creds;}const plain='\\uFEFF{\"a\":1}';const base64=Buffer.from('{\"b\":2}').toString('base64');console.log('plain',parseCreds(plain));console.log('base64',parseCreds(base64));"`


------
https://chatgpt.com/codex/tasks/task_e_6890e6405acc832aaabfe016796e03ab