### PR TITLE
Robust Google credentials parsing without newline replacement

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,13 +52,14 @@ async function getPricingSheetData(retries = 3) {
             .replace(new RegExp('^\\uFEFF'), ''); // remove BOM if present
         let creds;
         try {
-            // First attempt to parse as plain JSON with escaped newlines
-            creds = JSON.parse(cleanedCreds.replace(/\\n/g, '\n'));
+            // First attempt to parse as plain JSON
+            creds = JSON.parse(cleanedCreds);
         } catch (e) {
             try {
                 // If direct parse fails, attempt base64 decoding then parse
                 const decoded = Buffer.from(cleanedCreds, 'base64').toString('utf8');
-                creds = JSON.parse(decoded.replace(/\\n/g, '\n'));
+                const sanitized = decoded.trim().replace(new RegExp('^\\uFEFF'), '');
+                creds = JSON.parse(sanitized);
             } catch (err) {
                 console.error('Failed to parse GOOGLE_CREDENTIALS JSON:', err.message);
                 throw new Error('Invalid GOOGLE_CREDENTIALS environment variable. Ensure it is valid JSON or base64-encoded JSON.');

--- a/tests/credentialsParsing.demo.js
+++ b/tests/credentialsParsing.demo.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+function parseGoogleCredentials(raw) {
+  const cleaned = raw.trim().replace(/^\uFEFF/, '');
+  try {
+    return JSON.parse(cleaned);
+  } catch (e) {
+    try {
+      const decoded = Buffer.from(cleaned, 'base64').toString('utf8');
+      const sanitized = decoded.trim().replace(/^\uFEFF/, '');
+      return JSON.parse(sanitized);
+    } catch (err) {
+      console.error('Failed to parse GOOGLE_CREDENTIALS JSON:', err.message);
+      throw new Error('Invalid GOOGLE_CREDENTIALS environment variable. Ensure it is valid JSON or base64-encoded JSON.');
+    }
+  }
+}
+
+const sample = JSON.stringify({ project_id: 'demo-project', private_key: 'dummy' });
+const base64 = Buffer.from(sample, 'utf8').toString('base64');
+
+assert.deepStrictEqual(parseGoogleCredentials(sample), JSON.parse(sample));
+assert.deepStrictEqual(parseGoogleCredentials(base64), JSON.parse(sample));
+
+console.log('Credential parsing succeeded for both plain JSON and base64 inputs.');


### PR DESCRIPTION
## Summary
- Remove newline replacement when parsing GOOGLE_CREDENTIALS
- Fallback to base64 decoding with trim and BOM stripping before parsing
- Add demo script validating parsing for plain JSON and base64 credentials

## Testing
- `npm test`
- `node tests/credentialsParsing.demo.js`


------
https://chatgpt.com/codex/tasks/task_e_6890efca62b4832ab11b72229a4ca064