### PR TITLE
Ensure CORS headers on Lambda responses

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -1,4 +1,22 @@
 const serverless = require('serverless-http');
 const app = require('./server');
 
-module.exports.handler = serverless(app);
+// Wrap the Express app for AWS Lambda and manually ensure CORS headers are
+// always present on the response. Some Lambda deployments (e.g. function URLs)
+// ignore multi-value headers set by the `cors` middleware, so we merge the
+// header values after the request has been handled.
+const handler = serverless(app);
+
+module.exports.handler = async (event, context) => {
+  const response = await handler(event, context);
+
+  const origin = process.env.CORS_ORIGIN || '*';
+  response.headers = {
+    ...response.headers,
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Headers': 'Content-Type,x-admin-token',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  };
+
+  return response;
+};


### PR DESCRIPTION
## Summary
- ensure Lambda responses always include CORS headers by merging headers after serverless handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68910ccfbb7c832a95316e3839888225