### PR TITLE
Ensure iframe uses responsive viewport and tailwind CSS

### DIFF
--- a/MANUAL_TEST_PLAN.md
+++ b/MANUAL_TEST_PLAN.md
@@ -1,0 +1,13 @@
+# Manual Test Plan
+
+## Slide Editor Responsive Resize
+
+### Desktop
+1. Start the web app and navigate to the Slide Editor page.
+2. Resize the browser window between narrow and wide widths.
+3. Confirm the slide content within the iframe scales to fit without horizontal scrolling.
+
+### Mobile
+1. Open the Slide Editor page on a mobile device or emulator.
+2. Rotate the device between portrait and landscape orientations.
+3. Verify the slide content remains readable and adjusts to the viewport.

--- a/sow-web/src/pages/SlideEditorPage.tsx
+++ b/sow-web/src/pages/SlideEditorPage.tsx
@@ -126,10 +126,14 @@ export default function SlideEditorPage() {
     if (diff || !iframeRef.current || !selected) return;
     const doc = iframeRef.current.contentDocument;
     if (!doc) return;
+    const tailwindUrl = new URL('/tailwind.css', window.location.origin).toString();
     doc.open();
-    doc.write(`<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/>\n` +
-      `<link rel="stylesheet" href="/tailwind.css">` +
-      `</head><body class="p-4">${selected.currentHtml}</body></html>`);
+    doc.write(
+      `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"/>` +
+        `<meta name="viewport" content="width=device-width, initial-scale=1"/>` +
+        `<link rel="stylesheet" href="${tailwindUrl}">` +
+        `</head><body class="p-4">${selected.currentHtml}</body></html>`
+    );
     doc.close();
   }, [selected, diff]);
 


### PR DESCRIPTION
## Summary
- Inject viewport meta and absolute tailwind.css URL into slide editor iframe
- Add manual test plan for desktop and mobile resizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f3a15a74832a924264be9c3a82e4